### PR TITLE
feat: Party Guest can view live Queue at Fissa (Feature #45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.4
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node 20
         uses: actions/setup-node@v3

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "lint:fix": "pnpm lint --fix",
     "preview": "vite preview",
+    "test": "vitest run",
     "type-check": "tsc --noEmit",
     "with-env": "dotenv -e ../../.env --"
   },
@@ -38,6 +39,8 @@
   "devDependencies": {
     "@fissa/eslint-config": "*",
     "@tanstack/router-plugin": "^1.114.23",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "20.12.11",
     "@types/react": "18.2.37",
     "@types/react-dom": "18.2.15",
@@ -45,6 +48,7 @@
     "autoprefixer": "10.4.19",
     "dotenv-cli": "7.4.2",
     "eslint": "8.57.0",
+    "jsdom": "^29.0.2",
     "postcss": "8.4.38",
     "tailwindcss": "3.3.1",
     "typescript": "~5.8.3",

--- a/apps/web/src/components/CurrentlyPlayingTrack.test.tsx
+++ b/apps/web/src/components/CurrentlyPlayingTrack.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Tests for CurrentlyPlayingTrack component (Task #59)
+ *
+ * Scenario: Currently playing track is rendered on page load
+ * Scenario: No currently playing track
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { CurrentlyPlayingTrack } from "./CurrentlyPlayingTrack";
+
+const mockTrack = {
+  trackId: "4uLU6hMCjMI75M1A2tKUQC",
+  durationMs: 210000,
+  score: 3,
+  totalScore: 10,
+  hasBeenPlayed: false,
+};
+
+describe("CurrentlyPlayingTrack", () => {
+  /**
+   * Scenario: Currently playing track is rendered on page load
+   *   Then the currently playing track's artwork is visible
+   *   And a progress indicator is shown
+   */
+  it("renders track artwork when a track is provided", () => {
+    render(<CurrentlyPlayingTrack track={mockTrack} />);
+
+    const artwork = screen.getByTestId("track-artwork");
+    expect(artwork).toBeInTheDocument();
+    expect(artwork).toHaveAttribute("src", expect.stringContaining(mockTrack.trackId));
+  });
+
+  it("renders a progress indicator when a track is provided", () => {
+    render(<CurrentlyPlayingTrack track={mockTrack} />);
+
+    expect(screen.getByTestId("track-progress")).toBeInTheDocument();
+  });
+
+  it("renders a track-id element when a track is provided", () => {
+    render(<CurrentlyPlayingTrack track={mockTrack} />);
+
+    const idEl = screen.getByTestId("track-id");
+    expect(idEl).toHaveTextContent(mockTrack.trackId);
+  });
+
+  /**
+   * Scenario: No currently playing track
+   *   Then the CurrentlyPlayingTrack slot is empty or shows a placeholder
+   */
+  it("renders nothing when track is undefined", () => {
+    const { container } = render(<CurrentlyPlayingTrack track={undefined} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/src/components/CurrentlyPlayingTrack.tsx
+++ b/apps/web/src/components/CurrentlyPlayingTrack.tsx
@@ -1,0 +1,49 @@
+import { type FC } from "react";
+
+interface CurrentlyPlayingTrackProps {
+  track:
+    | {
+        trackId: string;
+        durationMs: number;
+        score: number;
+        totalScore: number;
+        hasBeenPlayed: boolean;
+      }
+    | undefined;
+}
+
+/**
+ * Renders the currently playing track with artwork, track ID, and a progress bar.
+ * Returns null when no track is provided.
+ */
+export const CurrentlyPlayingTrack: FC<CurrentlyPlayingTrackProps> = ({ track }) => {
+  if (!track) return null;
+
+  const artworkUrl = `https://i.scdn.co/image/ab67616d00004851${track.trackId}`;
+
+  return (
+    <div className="flex items-center gap-4">
+      <img
+        data-testid="track-artwork"
+        src={artworkUrl}
+        alt="Album artwork"
+        width={80}
+        height={80}
+        className="rounded-md object-cover"
+      />
+
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <p data-testid="track-id" className="sr-only">
+          {track.trackId}
+        </p>
+
+        <div
+          data-testid="track-progress"
+          className="h-1 w-full overflow-hidden rounded-full bg-white/20"
+        >
+          <div className="h-full w-1/3 rounded-full bg-white/80" />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/QueueTrackList.test.tsx
+++ b/apps/web/src/components/QueueTrackList.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Tests for QueueTrackList component (Task #61)
+ *
+ * Scenario: Queue is displayed in vote-ranked order
+ * Scenario: Already-played tracks are excluded from the queue
+ * Scenario: Currently playing track is excluded from the queue
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import React from "react";
+import { QueueTrackList } from "./QueueTrackList";
+
+const makeTracks = (overrides: Array<Partial<{ trackId: string; totalScore: number; hasBeenPlayed: boolean; durationMs: number }>>) =>
+  overrides.map((t, i) => ({
+    trackId: t.trackId ?? `track-${i}`,
+    totalScore: t.totalScore ?? 0,
+    hasBeenPlayed: t.hasBeenPlayed ?? false,
+    durationMs: t.durationMs ?? 180000,
+  }));
+
+describe("QueueTrackList", () => {
+  /**
+   * Scenario: Queue is displayed in vote-ranked order
+   *   Given the Fissa has multiple upcoming tracks with varying totalScore values
+   *   Then the tracks are ordered from highest totalScore to lowest
+   */
+  it("renders a list container with data-testid='track-list'", () => {
+    render(<QueueTrackList tracks={makeTracks([{ totalScore: 5 }])} />);
+
+    expect(screen.getByTestId("track-list")).toBeInTheDocument();
+  });
+
+  it("renders each track as an item with data-testid='track-item'", () => {
+    render(
+      <QueueTrackList
+        tracks={makeTracks([
+          { trackId: "track-a", totalScore: 1 },
+          { trackId: "track-b", totalScore: 2 },
+        ])}
+      />,
+    );
+
+    const items = screen.getAllByTestId("track-item");
+    expect(items).toHaveLength(2);
+  });
+
+  it("renders tracks sorted by totalScore descending", () => {
+    render(
+      <QueueTrackList
+        tracks={makeTracks([
+          { trackId: "track-low", totalScore: 1 },
+          { trackId: "track-high", totalScore: 10 },
+          { trackId: "track-mid", totalScore: 5 },
+        ])}
+      />,
+    );
+
+    const items = screen.getAllByTestId("track-item");
+    expect(items[0]).toHaveAttribute("data-trackid", "track-high");
+    expect(items[1]).toHaveAttribute("data-trackid", "track-mid");
+    expect(items[2]).toHaveAttribute("data-trackid", "track-low");
+  });
+
+  it("shows artwork for each track", () => {
+    render(
+      <QueueTrackList
+        tracks={makeTracks([{ trackId: "track-a", totalScore: 5 }])}
+      />,
+    );
+
+    const artwork = screen.getByTestId("queue-track-artwork-track-a");
+    expect(artwork).toBeInTheDocument();
+    expect(artwork).toHaveAttribute("src", expect.stringContaining("track-a"));
+  });
+
+  it("shows the track identifier for each track", () => {
+    render(
+      <QueueTrackList
+        tracks={makeTracks([{ trackId: "track-xyz", totalScore: 3 }])}
+      />,
+    );
+
+    const item = screen.getByTestId("track-item");
+    expect(within(item).getByTestId("queue-track-id-track-xyz")).toBeInTheDocument();
+  });
+
+  it("shows the vote tally (totalScore) for each track", () => {
+    render(
+      <QueueTrackList
+        tracks={makeTracks([
+          { trackId: "track-a", totalScore: 7 },
+          { trackId: "track-b", totalScore: -2 },
+        ])}
+      />,
+    );
+
+    expect(screen.getByTestId("queue-track-score-track-a")).toHaveTextContent("7");
+    expect(screen.getByTestId("queue-track-score-track-b")).toHaveTextContent("-2");
+  });
+
+  /**
+   * Scenario: Already-played tracks passed to QueueTrackList are excluded
+   *   (Defensive: even if parent mistakenly passes played tracks they should be filtered out)
+   */
+  it("does not render tracks with hasBeenPlayed=true", () => {
+    render(
+      <QueueTrackList
+        tracks={makeTracks([
+          { trackId: "track-played", totalScore: 5, hasBeenPlayed: true },
+          { trackId: "track-upcoming", totalScore: 3, hasBeenPlayed: false },
+        ])}
+      />,
+    );
+
+    const items = screen.getAllByTestId("track-item");
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveAttribute("data-trackid", "track-upcoming");
+  });
+
+  it("renders an empty list container when all tracks have been played", () => {
+    render(
+      <QueueTrackList
+        tracks={makeTracks([{ trackId: "track-played", totalScore: 5, hasBeenPlayed: true }])}
+      />,
+    );
+
+    const list = screen.getByTestId("track-list");
+    expect(list).toBeInTheDocument();
+    expect(screen.queryAllByTestId("track-item")).toHaveLength(0);
+  });
+});

--- a/apps/web/src/components/QueueTrackList.tsx
+++ b/apps/web/src/components/QueueTrackList.tsx
@@ -1,0 +1,65 @@
+import { type FC } from "react";
+
+interface QueueTrack {
+  trackId: string;
+  totalScore: number;
+  hasBeenPlayed: boolean;
+  durationMs: number;
+}
+
+interface QueueTrackListProps {
+  tracks: QueueTrack[];
+}
+
+/**
+ * Renders the upcoming tracks queue sorted by totalScore descending.
+ * Each track shows artwork (Spotify CDN), track identifier, and vote tally.
+ * Defensively filters out already-played tracks.
+ */
+export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks }) => {
+  const sorted = [...tracks]
+    .filter((t) => !t.hasBeenPlayed)
+    .sort((a, b) => b.totalScore - a.totalScore);
+
+  return (
+    <ul data-testid="track-list" className="flex flex-col gap-3">
+      {sorted.map((track) => {
+        const artworkUrl = `https://i.scdn.co/image/ab67616d00004851${track.trackId}`;
+
+        return (
+          <li
+            key={track.trackId}
+            data-testid="track-item"
+            data-trackid={track.trackId}
+            className="flex items-center gap-3"
+          >
+            <img
+              data-testid={`queue-track-artwork-${track.trackId}`}
+              src={artworkUrl}
+              alt="Album artwork"
+              width={56}
+              height={56}
+              className="rounded-md object-cover"
+            />
+
+            <div className="flex min-w-0 flex-1 flex-col">
+              <p
+                data-testid={`queue-track-id-${track.trackId}`}
+                className="truncate text-sm font-medium"
+              >
+                {track.trackId}
+              </p>
+            </div>
+
+            <span
+              data-testid={`queue-track-score-${track.trackId}`}
+              className="text-sm font-semibold tabular-nums"
+            >
+              {track.totalScore}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -423,3 +423,173 @@ describe("/fissa/$pin — Fissa-not-found and Fissa-ended states (Task #64)", ()
     expect(screen.queryByTestId("queue-signin-cta")).not.toBeInTheDocument();
   });
 });
+
+describe("/fissa/$pin — Empty queue state (Task #65)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+  });
+
+  /**
+   * Scenario: Active Fissa with no upcoming tracks
+   *   Given a valid Fissa PIN with an active Fissa
+   *   And the Fissa has only one track which is currently playing
+   *   When the visitor navigates to /fissa/<pin>
+   *   Then an empty-queue message is shown in the queue area (data-testid="queue-empty")
+   */
+  it("shows empty-queue message when the only track is currently playing", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: "track-1",
+        tracks: [
+          { trackId: "track-1", hasBeenPlayed: false, durationMs: 210000, score: 0, totalScore: 0 },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("queue-empty")).toBeInTheDocument();
+    expect(screen.getByTestId("queue-empty")).toHaveTextContent(/no upcoming tracks/i);
+  });
+
+  /**
+   * Scenario: Active Fissa where all tracks have been played
+   *   Given all tracks have hasBeenPlayed: true except the currently playing one
+   *   Then an appropriate empty-queue state is displayed
+   */
+  it("shows empty-queue message when all non-playing tracks have been played", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: "track-1",
+        tracks: [
+          { trackId: "track-1", hasBeenPlayed: false, durationMs: 210000, score: 0, totalScore: 0 },
+          { trackId: "track-2", hasBeenPlayed: true, durationMs: 180000, score: 0, totalScore: 0 },
+          { trackId: "track-3", hasBeenPlayed: true, durationMs: 200000, score: 0, totalScore: 0 },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("queue-empty")).toBeInTheDocument();
+    expect(screen.getByTestId("queue-empty")).toHaveTextContent(/no upcoming tracks/i);
+  });
+
+  /**
+   * Scenario: Empty queue transitions to populated queue on next poll
+   *   When new tracks are added and next poll completes
+   *   Then data-testid="queue-empty" is NOT present when upcomingTracks.length > 0
+   */
+  it("does not show empty-queue message when there are upcoming tracks", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: "track-1",
+        tracks: [
+          { trackId: "track-1", hasBeenPlayed: false, durationMs: 210000, score: 0, totalScore: 0 },
+          { trackId: "track-2", hasBeenPlayed: false, durationMs: 180000, score: 0, totalScore: 0 },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByTestId("queue-empty")).not.toBeInTheDocument();
+  });
+
+  /**
+   * Empty-queue message must NOT appear when Fissa is loading
+   */
+  it("does not show empty-queue message while loading", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByTestId("queue-empty")).not.toBeInTheDocument();
+  });
+
+  /**
+   * Empty-queue message must NOT appear when Fissa is not found
+   */
+  it("does not show empty-queue message when Fissa is not found", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { message: "Fissa not found" },
+    } as any);
+
+    render(<QueuePage pin="XXXX" />);
+
+    expect(screen.queryByTestId("queue-empty")).not.toBeInTheDocument();
+  });
+
+  /**
+   * Empty-queue message must NOT appear when Fissa has ended
+   */
+  it("does not show empty-queue message when Fissa has ended", () => {
+    const pastTime = new Date(Date.now() - 1000 * 60 * 60);
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: null,
+        expectedEndTime: pastTime,
+        tracks: [],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByTestId("queue-empty")).not.toBeInTheDocument();
+  });
+
+  /**
+   * Currently playing track must still be shown even when queue is empty
+   */
+  it("still shows the currently playing track alongside the empty-queue message", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: "track-1",
+        tracks: [
+          { trackId: "track-1", hasBeenPlayed: false, durationMs: 210000, score: 0, totalScore: 0 },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("queue-now-playing")).toBeInTheDocument();
+    expect(screen.getByTestId("currently-playing-track")).toBeInTheDocument();
+    expect(screen.getByTestId("queue-empty")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -32,6 +32,9 @@ vi.mock("~/providers/ThemeProvider", () => ({
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => () => ({ component: null }),
   useNavigate: () => vi.fn(),
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string; [key: string]: unknown }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
 }));
 
 vi.mock("~/components/Layout", () => ({
@@ -233,5 +236,190 @@ describe("/fissa/$pin — Currently playing track (Task #59)", () => {
     render(<QueuePage pin="ABC123" />);
 
     expect(screen.queryByTestId("currently-playing-track")).not.toBeInTheDocument();
+  });
+});
+
+describe("/fissa/$pin — Fissa-not-found and Fissa-ended states (Task #64)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+  });
+
+  /**
+   * Scenario: PIN does not correspond to an active Fissa
+   *   Given a visitor navigates to /fissa/<invalid-pin>
+   *   When fissa.byId returns a NOT_FOUND error
+   *   Then a "Fissa not found" message is shown
+   *   And a link or button to go home is displayed
+   *   And the page does not crash
+   */
+  it("shows Fissa-not-found UI when the query returns an error", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { message: "Fissa not found: XXXX" },
+    } as any);
+
+    render(<QueuePage pin="XXXX" />);
+
+    expect(screen.getByTestId("fissa-not-found")).toBeInTheDocument();
+    expect(screen.getByTestId("fissa-not-found")).toHaveTextContent(/fissa not found/i);
+    expect(screen.getByTestId("go-home-link")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: PIN does not correspond to an active Fissa — page does not crash
+   *   The queue sections must NOT be rendered when error state is active.
+   */
+  it("does not render queue sections when isError is true", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { message: "Fissa not found: XXXX" },
+    } as any);
+
+    render(<QueuePage pin="XXXX" />);
+
+    expect(screen.queryByTestId("queue-now-playing")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("queue-upcoming")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("queue-signin-cta")).not.toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Visitor arrives after Fissa has already ended
+   *   Given a Fissa that has ended (expectedEndTime is in the past)
+   *   When a visitor navigates to /fissa/<pin>
+   *   Then a "Fissa has ended" message is shown immediately
+   *   And a link or button to go home is displayed
+   */
+  it("shows Fissa-ended UI when expectedEndTime is in the past", () => {
+    const pastTime = new Date(Date.now() - 1000 * 60 * 60); // 1 hour ago
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: null,
+        expectedEndTime: pastTime,
+        tracks: [],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("fissa-ended")).toBeInTheDocument();
+    expect(screen.getByTestId("fissa-ended")).toHaveTextContent(/fissa has ended/i);
+    expect(screen.getByTestId("go-home-link")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Fissa has ended — queue sections must not be rendered
+   */
+  it("does not render queue sections when Fissa has ended", () => {
+    const pastTime = new Date(Date.now() - 1000 * 60 * 60);
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: null,
+        expectedEndTime: pastTime,
+        tracks: [],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByTestId("queue-now-playing")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("queue-upcoming")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("queue-signin-cta")).not.toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Fissa ends while visitor is watching
+   *   Given a visitor is viewing an active Fissa page
+   *   When the next poll detects expectedEndTime has passed
+   *   Then the page transitions to a "Fissa has ended" message
+   */
+  it("transitions to Fissa-ended state when expectedEndTime passes during polling", () => {
+    // First render with active fissa
+    const futureTime = new Date(Date.now() + 1000 * 60); // 1 minute in future
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: "trackId",
+        expectedEndTime: futureTime,
+        tracks: [{ trackId: "trackId", durationMs: 210000, score: 0, totalScore: 0, hasBeenPlayed: false }],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    const { rerender } = render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByTestId("fissa-ended")).not.toBeInTheDocument();
+
+    // Simulate poll returning ended state
+    const pastTime = new Date(Date.now() - 1000);
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: null,
+        expectedEndTime: pastTime,
+        tracks: [],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    rerender(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("fissa-ended")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Loading state is shown while query is in-flight
+   */
+  it("shows a loading indicator while the query is loading", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("fissa-loading")).toBeInTheDocument();
+  });
+
+  /**
+   * Loading state — queue sections must not be rendered while loading
+   */
+  it("does not render queue sections while loading", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByTestId("queue-now-playing")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("queue-upcoming")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("queue-signin-cta")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Tests for /fissa/$pin page (Task #57)
+ *
+ * Scenario: Fissa page renders layout without automatic redirect
+ * Scenario: Visitor with native app installed is not auto-redirected
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+// Note: vi.mock factories are hoisted — no variable references allowed inside.
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    fissa: {
+      byId: {
+        useQuery: vi.fn().mockReturnValue({
+          data: undefined,
+          isLoading: true,
+          error: null,
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("~/providers/ThemeProvider", () => ({
+  useTheme: () => ({ theme: { 500: "#ff0", 900: "#000" } }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => () => ({ component: null }),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("~/components/Layout", () => ({
+  Layout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="layout">{children}</div>
+  ),
+}));
+
+vi.mock("~/components/Container", () => ({
+  Container: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
+vi.mock("~/components/Button", () => ({
+  Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+}));
+
+vi.mock("~/components/Toast", () => ({
+  toast: { error: vi.fn() },
+}));
+
+// ── Imports after mocks ────────────────────────────────────────────────────────
+
+import { api } from "~/utils/api";
+import { QueuePage } from "./$pin";
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("/fissa/$pin — Queue view layout scaffold", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as any);
+  });
+
+  /**
+   * Scenario: Fissa page renders layout without automatic redirect
+   *   Then the page displays a Queue view layout with the PIN
+   */
+  it("renders the Queue layout scaffold with the Fissa PIN", () => {
+    mockUseQuery.mockReturnValue({
+      data: { pin: "ABC123" },
+      isLoading: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    // PIN is visible in the header area
+    expect(screen.getByText(/ABC123/)).toBeInTheDocument();
+
+    // Queue view sections are present as placeholders
+    expect(screen.getByTestId("queue-now-playing")).toBeInTheDocument();
+    expect(screen.getByTestId("queue-upcoming")).toBeInTheDocument();
+    expect(screen.getByTestId("queue-signin-cta")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Fissa page renders layout without automatic redirect
+   *   Then the Party Guest remains on "/fissa/ABC123"
+   *   (i.e. no window.location.replace is called on load)
+   */
+  it("does not call window.location.replace when query succeeds", () => {
+    const replaceSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, replace: replaceSpy },
+      writable: true,
+      configurable: true,
+    });
+
+    // Simulate the query succeeding — if onSuccess is still in the code it would fire
+    mockUseQuery.mockImplementation((_pin: string, options?: { onSuccess?: (data: unknown) => void }) => {
+      options?.onSuccess?.({ pin: "ABC123" });
+      return { data: { pin: "ABC123" }, isLoading: false, error: null } as any;
+    });
+
+    render(<QueuePage pin="ABC123" />);
+
+    // No deep-link redirect should have been triggered
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Scenario: Visitor with native app installed is not auto-redirected
+   *   Then the browser does not navigate away from "/fissa/ABC123"
+   *   And no deep-link redirect is triggered automatically
+   */
+  it("does not trigger a com.fissa:// deep-link redirect automatically", () => {
+    const replaceSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, replace: replaceSpy },
+      writable: true,
+      configurable: true,
+    });
+
+    mockUseQuery.mockReturnValue({
+      data: { pin: "ABC123" },
+      isLoading: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(replaceSpy).not.toHaveBeenCalled();
+    expect(replaceSpy).not.toHaveBeenCalledWith(expect.stringContaining("com.fissa://"));
+  });
+
+  /**
+   * The "Join Fissa" button (which called window.location.replace) must be removed.
+   */
+  it("does not render the old 'Join Fissa' button", () => {
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByRole("button", { name: /join fissa/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -593,3 +593,116 @@ describe("/fissa/$pin — Empty queue state (Task #65)", () => {
     expect(screen.getByTestId("queue-empty")).toBeInTheDocument();
   });
 });
+
+describe("/fissa/$pin — Upcoming tracks list (Task #61)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+  });
+
+  /**
+   * Scenario: Queue is displayed in vote-ranked order
+   *   Given the Fissa has multiple upcoming tracks
+   *   Then the upcoming tracks list (track-list) is shown inside queue-upcoming
+   *   And played tracks are not shown
+   *   And the currently playing track is not shown
+   */
+  it("renders the track list when there are upcoming tracks", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: "track-1",
+        tracks: [
+          { trackId: "track-1", hasBeenPlayed: false, durationMs: 210000, score: 0, totalScore: 5 },
+          { trackId: "track-2", hasBeenPlayed: false, durationMs: 180000, score: 0, totalScore: 3 },
+          { trackId: "track-3", hasBeenPlayed: false, durationMs: 200000, score: 0, totalScore: 8 },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("track-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("queue-empty")).not.toBeInTheDocument();
+  });
+
+  it("does not render the currently playing track in the upcoming list", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: "track-1",
+        tracks: [
+          { trackId: "track-1", hasBeenPlayed: false, durationMs: 210000, score: 0, totalScore: 5 },
+          { trackId: "track-2", hasBeenPlayed: false, durationMs: 180000, score: 0, totalScore: 3 },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    const items = screen.getAllByTestId("track-item");
+    // only track-2 appears in the list (track-1 is currently playing)
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveAttribute("data-trackid", "track-2");
+  });
+
+  it("does not render already-played tracks in the upcoming list", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: "track-1",
+        tracks: [
+          { trackId: "track-1", hasBeenPlayed: false, durationMs: 210000, score: 0, totalScore: 5 },
+          { trackId: "track-2", hasBeenPlayed: true, durationMs: 180000, score: 0, totalScore: 3 },
+          { trackId: "track-3", hasBeenPlayed: false, durationMs: 200000, score: 0, totalScore: 1 },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    const items = screen.getAllByTestId("track-item");
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveAttribute("data-trackid", "track-3");
+  });
+
+  it("renders tracks sorted by totalScore descending in the queue", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: "track-1",
+        tracks: [
+          { trackId: "track-1", hasBeenPlayed: false, durationMs: 210000, score: 0, totalScore: 5 },
+          { trackId: "track-low", hasBeenPlayed: false, durationMs: 180000, score: 0, totalScore: 1 },
+          { trackId: "track-high", hasBeenPlayed: false, durationMs: 200000, score: 0, totalScore: 9 },
+          { trackId: "track-mid", hasBeenPlayed: false, durationMs: 200000, score: 0, totalScore: 4 },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    const items = screen.getAllByTestId("track-item");
+    expect(items[0]).toHaveAttribute("data-trackid", "track-high");
+    expect(items[1]).toHaveAttribute("data-trackid", "track-mid");
+    expect(items[2]).toHaveAttribute("data-trackid", "track-low");
+  });
+});

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -56,6 +56,11 @@ vi.mock("~/components/Toast", () => ({
   toast: { error: vi.fn() },
 }));
 
+vi.mock("~/components/CurrentlyPlayingTrack", () => ({
+  CurrentlyPlayingTrack: ({ track }: { track?: { trackId: string } }) =>
+    track ? <div data-testid="currently-playing-track">{track.trackId}</div> : null,
+}));
+
 // ── Imports after mocks ────────────────────────────────────────────────────────
 
 import { api } from "~/utils/api";
@@ -153,5 +158,80 @@ describe("/fissa/$pin — Queue view layout scaffold", () => {
     render(<QueuePage pin="ABC123" />);
 
     expect(screen.queryByRole("button", { name: /join fissa/i })).not.toBeInTheDocument();
+  });
+});
+
+describe("/fissa/$pin — Currently playing track (Task #59)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as any);
+  });
+
+  /**
+   * Scenario: Currently playing track is rendered on page load
+   *   Given a valid Fissa PIN with an active Fissa
+   *   And the Fissa has a currentlyPlayingId set
+   *   When the visitor navigates to /fissa/<pin>
+   *   Then the currently playing track is rendered in the now-playing slot
+   */
+  it("renders the currently playing track when currentlyPlayingId matches a track", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: "4uLU6hMCjMI75M1A2tKUQC",
+        tracks: [
+          {
+            trackId: "4uLU6hMCjMI75M1A2tKUQC",
+            durationMs: 210000,
+            score: 3,
+            totalScore: 10,
+            hasBeenPlayed: false,
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("currently-playing-track")).toBeInTheDocument();
+    expect(screen.getByTestId("currently-playing-track")).toHaveTextContent("4uLU6hMCjMI75M1A2tKUQC");
+  });
+
+  /**
+   * Scenario: No currently playing track
+   *   Given a valid Fissa PIN with an active Fissa
+   *   And the Fissa has no currentlyPlayingId set
+   *   When the visitor navigates to /fissa/<pin>
+   *   Then the CurrentlyPlayingTrack slot is empty
+   */
+  it("renders nothing in the now-playing slot when currentlyPlayingId is null", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: null,
+        tracks: [
+          {
+            trackId: "4uLU6hMCjMI75M1A2tKUQC",
+            durationMs: 210000,
+            score: 3,
+            totalScore: 10,
+            hasBeenPlayed: false,
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByTestId("currently-playing-track")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -594,6 +594,84 @@ describe("/fissa/$pin — Empty queue state (Task #65)", () => {
   });
 });
 
+describe("/fissa/$pin — Auto-polling every 5 seconds (Task #62)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    } as any);
+  });
+
+  /**
+   * Scenario: Queue updates automatically while tab is active
+   *   Given a visitor is viewing the Fissa page
+   *   When 5 seconds elapse
+   *   Then the queue and currently playing track are refreshed without a page reload
+   *   (verify refetchInterval: 5000 is passed to useQuery)
+   */
+  it("passes refetchInterval: 5000 to useQuery", () => {
+    render(<QueuePage pin="ABC123" />);
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      "ABC123",
+      expect.objectContaining({ refetchInterval: 5000 }),
+    );
+  });
+
+  /**
+   * Scenario: Polling pauses when tab is hidden
+   *   Given a visitor is viewing the Fissa page
+   *   When the visitor switches to another browser tab
+   *   Then no new requests are sent to fissa.byId
+   *   (verify refetchIntervalInBackground: false is passed to useQuery)
+   */
+  it("passes refetchIntervalInBackground: false to useQuery", () => {
+    render(<QueuePage pin="ABC123" />);
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      "ABC123",
+      expect.objectContaining({ refetchIntervalInBackground: false }),
+    );
+  });
+
+  /**
+   * Scenario: Network error during polling preserves last known queue
+   *   Given a visitor is viewing the Fissa page
+   *   And the queue has loaded successfully
+   *   When a refetch request fails due to a network error
+   *   Then the previously loaded queue remains visible
+   *   And the page does not crash or show an empty state
+   */
+  it("keeps the previously loaded queue visible when a poll fails with a network error", () => {
+    // Simulate useQuery returning stale data alongside isError: true
+    // (React Query preserves previous data on refetch failure)
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: "track-1",
+        tracks: [
+          { trackId: "track-1", hasBeenPlayed: false, durationMs: 210000, score: 0, totalScore: 5 },
+          { trackId: "track-2", hasBeenPlayed: false, durationMs: 180000, score: 0, totalScore: 3 },
+        ],
+      },
+      isLoading: false,
+      isError: true,
+      error: { message: "Network Error" },
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    // Queue sections must still be visible (data is preserved)
+    expect(screen.getByTestId("queue-now-playing")).toBeInTheDocument();
+    expect(screen.getByTestId("queue-upcoming")).toBeInTheDocument();
+    expect(screen.queryByTestId("fissa-not-found")).not.toBeInTheDocument();
+  });
+});
+
 describe("/fissa/$pin — Upcoming tracks list (Task #61)", () => {
   const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
 

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { type FC } from "react";
+import { CurrentlyPlayingTrack } from "~/components/CurrentlyPlayingTrack";
 import { Layout } from "~/components/Layout";
 import { toast } from "~/components/Toast";
 import { api } from "~/utils/api";
@@ -15,7 +16,7 @@ interface QueuePageProps {
 export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
   const navigate = useNavigate();
 
-  api.fissa.byId.useQuery(pin, {
+  const { data } = api.fissa.byId.useQuery(pin, {
     retry: false,
     enabled: !!pin,
     onError: (error) => {
@@ -23,6 +24,10 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
       void navigate({ to: "/" });
     },
   });
+
+  const currentlyPlayingTrack = data?.tracks?.find(
+    (t) => t.trackId === data.currentlyPlayingId,
+  );
 
   return (
     <Layout>
@@ -34,7 +39,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
 
         {/* Currently-playing track slot */}
         <section data-testid="queue-now-playing" className="px-4 py-4">
-          {/* Placeholder — live track data wired in a later task */}
+          <CurrentlyPlayingTrack track={currentlyPlayingTrack} />
         </section>
 
         {/* Upcoming tracks list slot */}

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -1,29 +1,23 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useRef } from "react";
-import { Button } from "~/components/Button";
-import { Container } from "~/components/Container";
+import { type FC } from "react";
 import { Layout } from "~/components/Layout";
 import { toast } from "~/components/Toast";
-import { useTheme } from "~/providers/ThemeProvider";
 import { api } from "~/utils/api";
 
 export const Route = createFileRoute("/fissa/$pin")({
   component: JoinFissa,
 });
 
-function JoinFissa() {
-  const { pin } = Route.useParams();
-  const { theme } = useTheme();
-  const shown = useRef(false);
+interface QueuePageProps {
+  pin: string;
+}
+
+export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
   const navigate = useNavigate();
 
   api.fissa.byId.useQuery(pin, {
     retry: false,
-    enabled: !shown.current && !!pin,
-    onSuccess: (data) => {
-      shown.current = true;
-      window.location.replace(`com.fissa://fissa/${data.pin}`);
-    },
+    enabled: !!pin,
     onError: (error) => {
       toast.error({ message: error.message });
       void navigate({ to: "/" });
@@ -32,29 +26,32 @@ function JoinFissa() {
 
   return (
     <Layout>
-      <section
-        id="get-free-shares-today"
-        className="relative overflow-hidden py-48 sm:py-64"
-        style={{ backgroundColor: theme[900] }}
-      >
-        <Container className="relative">
-          <div className="mx-auto max-w-md sm:text-center">
-            <h2 className="text-3xl font-medium tracking-tight sm:text-4xl">
-              You have been invited to join Fissa {pin},
-            </h2>
-            <p className="mt-4 text-lg">become the DJ you have always dreamt to be.</p>
-            <Button
-              className="mt-8"
-              style={{ backgroundColor: theme[500], color: theme[900] }}
-              onClick={() => {
-                window.location.replace(`com.fissa://fissa/${pin}`);
-              }}
-            >
-              Join Fissa {pin}
-            </Button>
-          </div>
-        </Container>
-      </section>
+      <div className="flex min-h-screen flex-col">
+        {/* Header: Fissa PIN */}
+        <header className="px-4 py-6 text-center">
+          <h1 className="text-2xl font-bold tracking-widest">{pin}</h1>
+        </header>
+
+        {/* Currently-playing track slot */}
+        <section data-testid="queue-now-playing" className="px-4 py-4">
+          {/* Placeholder — live track data wired in a later task */}
+        </section>
+
+        {/* Upcoming tracks list slot */}
+        <section data-testid="queue-upcoming" className="flex-1 px-4 py-4">
+          {/* Placeholder — upcoming tracks list wired in a later task */}
+        </section>
+
+        {/* Unauthenticated sign-in CTA slot */}
+        <section data-testid="queue-signin-cta" className="px-4 py-6">
+          {/* Placeholder — sign-in CTA wired in a later task */}
+        </section>
+      </div>
     </Layout>
   );
+};
+
+function JoinFissa() {
+  const { pin } = Route.useParams();
+  return <QueuePage pin={pin} />;
 }

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { type FC } from "react";
 import { CurrentlyPlayingTrack } from "~/components/CurrentlyPlayingTrack";
 import { Layout } from "~/components/Layout";
+import { QueueTrackList } from "~/components/QueueTrackList";
 import { api } from "~/utils/api";
 
 export const Route = createFileRoute("/fissa/$pin")({
@@ -90,7 +91,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
               No upcoming tracks
             </p>
           ) : (
-            null /* Placeholder — upcoming tracks list wired in a later task */
+            <QueueTrackList tracks={upcomingTracks} />
           )}
         </section>
 

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -66,6 +66,10 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
     (t) => t.trackId === data.currentlyPlayingId,
   );
 
+  const upcomingTracks = data?.tracks?.filter(
+    (t) => !t.hasBeenPlayed && t.trackId !== data?.currentlyPlayingId,
+  ) ?? [];
+
   return (
     <Layout>
       <div className="flex min-h-screen flex-col">
@@ -81,7 +85,13 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
 
         {/* Upcoming tracks list slot */}
         <section data-testid="queue-upcoming" className="flex-1 px-4 py-4">
-          {/* Placeholder — upcoming tracks list wired in a later task */}
+          {upcomingTracks.length === 0 ? (
+            <p data-testid="queue-empty" className="text-center text-muted-foreground">
+              No upcoming tracks
+            </p>
+          ) : (
+            null /* Placeholder — upcoming tracks list wired in a later task */
+          )}
         </section>
 
         {/* Unauthenticated sign-in CTA slot */}

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -17,6 +17,8 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
   const { data, isLoading, isError } = api.fissa.byId.useQuery(pin, {
     retry: false,
     enabled: !!pin,
+    refetchInterval: 5000,
+    refetchIntervalInBackground: false,
   });
 
   if (isLoading) {
@@ -29,7 +31,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
     );
   }
 
-  if (isError) {
+  if (isError && !data) {
     return (
       <Layout>
         <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4 text-center">

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -1,8 +1,7 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { type FC } from "react";
 import { CurrentlyPlayingTrack } from "~/components/CurrentlyPlayingTrack";
 import { Layout } from "~/components/Layout";
-import { toast } from "~/components/Toast";
 import { api } from "~/utils/api";
 
 export const Route = createFileRoute("/fissa/$pin")({
@@ -14,16 +13,54 @@ interface QueuePageProps {
 }
 
 export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
-  const navigate = useNavigate();
-
-  const { data } = api.fissa.byId.useQuery(pin, {
+  const { data, isLoading, isError } = api.fissa.byId.useQuery(pin, {
     retry: false,
     enabled: !!pin,
-    onError: (error) => {
-      toast.error({ message: error.message });
-      void navigate({ to: "/" });
-    },
   });
+
+  if (isLoading) {
+    return (
+      <Layout>
+        <div data-testid="fissa-loading" className="flex min-h-screen items-center justify-center">
+          <p className="text-lg">Loading…</p>
+        </div>
+      </Layout>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Layout>
+        <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4 text-center">
+          <p data-testid="fissa-not-found" className="text-2xl font-bold">
+            Fissa not found
+          </p>
+          <Link data-testid="go-home-link" to="/" className="underline">
+            Go home
+          </Link>
+        </div>
+      </Layout>
+    );
+  }
+
+  const hasFissaEnded =
+    data?.expectedEndTime != null &&
+    new Date(data.expectedEndTime) < new Date();
+
+  if (hasFissaEnded) {
+    return (
+      <Layout>
+        <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4 text-center">
+          <p data-testid="fissa-ended" className="text-2xl font-bold">
+            Fissa has ended
+          </p>
+          <Link data-testid="go-home-link" to="/" className="underline">
+            Go home
+          </Link>
+        </div>
+      </Layout>
+    );
+  }
 
   const currentlyPlayingTrack = data?.tracks?.find(
     (t) => t.trackId === data.currentlyPlayingId,

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: [path.resolve(__dirname, "./src/test/setup.ts")],
+    clearMocks: true,
+    include: [path.resolve(__dirname, "./src/**/*.test.{ts,tsx}")],
+  },
+  resolve: {
+    alias: {
+      "~": path.resolve(__dirname, "./src"),
+      react: path.resolve(__dirname, "./node_modules/react"),
+      "react-dom": path.resolve(__dirname, "./node_modules/react-dom"),
+    },
+    dedupe: ["react", "react-dom"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 1.6.0
-        version: 1.6.0(@types/node@20.12.11)(lightningcss@1.32.0)(terser@5.30.4)
+        version: 1.6.0(@types/node@20.12.11)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.30.4)
 
   apps/expo:
     dependencies:
@@ -314,6 +314,12 @@ importers:
       '@tanstack/router-plugin':
         specifier: ^1.114.23
         version: 1.167.12(@tanstack/react-router@1.168.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.4.21(@types/node@20.12.11)(lightningcss@1.32.0)(terser@5.30.4))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/node':
         specifier: 20.12.11
         version: 20.12.11
@@ -335,6 +341,9 @@ importers:
       eslint:
         specifier: 8.57.0
         version: 8.57.0
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2(@noble/hashes@2.0.1)
       postcss:
         specifier: 8.4.38
         version: 8.4.38
@@ -398,7 +407,7 @@ importers:
         version: link:../env
       better-auth:
         specifier: ^1.2.7
-        version: 1.6.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0))(prisma@5.13.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@1.6.0(@types/node@20.12.11)(lightningcss@1.32.0)(terser@5.30.4))
+        version: 1.6.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0))(prisma@5.13.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@1.6.0(@types/node@20.12.11)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.30.4))
     devDependencies:
       '@fissa/eslint-config':
         specifier: '*'
@@ -507,7 +516,7 @@ importers:
         version: 0.1.2
       vitest-mock-extended:
         specifier: 1.3.1
-        version: 1.3.1(typescript@5.9.3)(vitest@1.6.0(@types/node@20.12.11)(lightningcss@1.32.0)(terser@5.30.4))
+        version: 1.3.1(typescript@5.9.3)(vitest@1.6.0(@types/node@20.12.11)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.30.4))
 
   packages/utils:
     dependencies:
@@ -550,6 +559,9 @@ packages:
       graphql:
         optional: true
 
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
@@ -557,6 +569,21 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.0':
+    resolution: {integrity: sha512-ASf825+5vsGuYWoyFyNsex2mNtPTXpCvYTR942+w/eNw7PqS0Lhl/PE1hC7bajneI3m/Oxi+yrP3vTOPxfwM8A==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.10.4':
     resolution: {integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==}
@@ -1382,6 +1409,46 @@ packages:
   '@better-fetch/fetch@1.1.21':
     resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
@@ -1996,6 +2063,15 @@ packages:
   '@eslint/js@8.57.0':
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@expo/cli@54.0.23':
     resolution: {integrity: sha512-km0h72SFfQCmVycH/JtPFTVy69w6Lx1cHNDmfLfQqgKFYeeHTjx7LVDP4POHCtNxFP2UeRazrygJhlh4zz498g==}
@@ -3525,6 +3601,29 @@ packages:
     engines: {node: '>=20.19'}
     hasBin: true
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@total-typescript/shoehorn@0.1.2':
     resolution: {integrity: sha512-p7nNZbOZIofpDNyP0u1BctFbjxD44Qc+oO5jufgQdFdGIXJLc33QRloJpq7k5T59CTgLWfQSUxsuqLcmeurYRw==}
 
@@ -3552,6 +3651,9 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: '>=5.7.2'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -4182,6 +4284,9 @@ packages:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
@@ -4483,6 +4588,13 @@ packages:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -4496,6 +4608,10 @@ packages:
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.1:
     resolution: {integrity: sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==}
@@ -4552,6 +4668,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
@@ -4650,6 +4769,12 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dotenv-cli@7.4.2:
     resolution: {integrity: sha512-SbUj8l61zIbzyhIbg0FwPJq6+wjbzdn9oEtozQpZ6kW2ihCcapKVZj49oCT3oPM+mgQm+itgvUQcG5szxVrZTA==}
@@ -4800,6 +4925,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   env-editor@0.4.2:
     resolution: {integrity: sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA==}
@@ -5574,6 +5703,10 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
 
@@ -5631,6 +5764,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -5760,6 +5897,9 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
@@ -5917,6 +6057,15 @@ packages:
 
   jsc-safe-url@0.2.4:
     resolution: {integrity: sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==}
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
@@ -6218,6 +6367,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.10:
     resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
 
@@ -6232,6 +6385,9 @@ packages:
 
   math-random@1.0.4:
     resolution: {integrity: sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
@@ -6416,6 +6572,10 @@ packages:
   mimic-response@4.0.0:
     resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -6713,6 +6873,9 @@ packages:
     resolution: {integrity: sha512-Nt/a5SfCLiTnQAjx3fHlqp8hRgTL3z7kTQZzvIMS9uCAepnCyjpdEc6M/sz69WqMBdaDBw9sF1F1UaHROYzGkQ==}
     engines: {node: '>=10'}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -6952,6 +7115,10 @@ packages:
   pretty-format@26.6.2:
     resolution: {integrity: sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==}
     engines: {node: '>= 10'}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
@@ -7196,6 +7363,10 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.6:
     resolution: {integrity: sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==}
     engines: {node: '>= 0.4'}
@@ -7356,6 +7527,10 @@ packages:
 
   sax@1.3.0:
     resolution: {integrity: sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -7610,6 +7785,10 @@ packages:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -7669,6 +7848,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
@@ -7745,6 +7927,13 @@ packages:
     resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -7760,8 +7949,16 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@1.3.0:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
@@ -7889,6 +8086,10 @@ packages:
   undici@6.24.1:
     resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
     engines: {node: '>=18.17'}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
@@ -8080,6 +8281,10 @@ packages:
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -8096,15 +8301,27 @@ packages:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
     engines: {node: '>=8'}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
   whatwg-url-without-unicode@8.0.0-3:
     resolution: {integrity: sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==}
     engines: {node: '>=10'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -8206,6 +8423,10 @@ packages:
     resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
     engines: {node: '>=10.0.0'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xml2js@0.6.0:
     resolution: {integrity: sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==}
     engines: {node: '>=4.0.0'}
@@ -8217,6 +8438,9 @@ packages:
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -8308,12 +8532,34 @@ snapshots:
     optionalDependencies:
       graphql: 15.8.0
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.0':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.10.4':
     dependencies:
@@ -9888,6 +10134,34 @@ snapshots:
 
   '@better-fetch/fetch@1.1.21': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@drizzle-team/brocli@0.10.2': {}
 
   '@egjs/hammerjs@2.0.17':
@@ -10217,6 +10491,10 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.0': {}
+
+  '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
+    optionalDependencies:
+      '@noble/hashes': 2.0.1
 
   ? '@expo/cli@54.0.23(expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@18.2.15)(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-reanimated@4.1.7(react-native-worklets@0.8.1(@babel/core@7.26.10)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo@54.0.33(@babel/core@7.26.10)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)'
   : dependencies:
@@ -12682,6 +12960,36 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.161.7': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.26.10
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@testing-library/dom': 10.4.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 18.2.15
+
   '@total-typescript/shoehorn@0.1.2': {}
 
   '@total-typescript/ts-reset@0.5.1': {}
@@ -12719,6 +13027,8 @@ snapshots:
   '@trpc/server@11.16.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -13549,7 +13859,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.17: {}
 
-  better-auth@1.6.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0))(prisma@5.13.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@1.6.0(@types/node@20.12.11)(lightningcss@1.32.0)(terser@5.30.4)):
+  better-auth@1.6.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0))(prisma@5.13.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@1.6.0(@types/node@20.12.11)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.30.4)):
     dependencies:
       '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0))
@@ -13575,7 +13885,7 @@ snapshots:
       prisma: 5.13.0
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      vitest: 1.6.0(@types/node@20.12.11)(lightningcss@1.32.0)(terser@5.30.4)
+      vitest: 1.6.0(@types/node@20.12.11)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.30.4)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -13592,6 +13902,10 @@ snapshots:
   better-opn@3.0.2:
     dependencies:
       open: 8.4.2
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   big-integer@1.6.52: {}
 
@@ -13935,6 +14249,13 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   csstype@3.1.3: {}
@@ -13942,6 +14263,13 @@ snapshots:
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@7.0.0(@noble/hashes@2.0.1):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.1:
     dependencies:
@@ -13984,6 +14312,8 @@ snapshots:
 
   decamelize@1.2.0:
     optional: true
+
+  decimal.js@10.6.0: {}
 
   decode-uri-component@0.2.2: {}
 
@@ -14057,6 +14387,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dotenv-cli@7.4.2:
     dependencies:
       cross-spawn: 7.0.3
@@ -14116,6 +14450,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@6.0.1: {}
 
   env-editor@0.4.2: {}
 
@@ -15350,6 +15686,12 @@ snapshots:
     dependencies:
       lru-cache: 10.2.1
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.0.1):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   http-cache-semantics@4.1.1: {}
 
   http-errors@2.0.1:
@@ -15418,6 +15760,8 @@ snapshots:
       module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -15533,6 +15877,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-regex@1.1.4:
     dependencies:
@@ -15722,6 +16068,32 @@ snapshots:
       argparse: 2.0.1
 
   jsc-safe-url@0.2.4: {}
+
+  jsdom@29.0.2(@noble/hashes@2.0.1):
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.0
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.0.1)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.0.1)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.3
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@0.5.0: {}
 
@@ -15957,6 +16329,8 @@ snapshots:
     dependencies:
       react: 18.2.0
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.10:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -15972,6 +16346,8 @@ snapshots:
   marky@1.2.5: {}
 
   math-random@1.0.4: {}
+
+  mdn-data@2.27.1: {}
 
   memoize-one@5.2.1: {}
 
@@ -16367,6 +16743,8 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -16658,6 +17036,10 @@ snapshots:
     dependencies:
       pngjs: 3.4.0
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
@@ -16815,6 +17197,12 @@ snapshots:
       react-is: 17.0.2
     optional: true
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -16916,8 +17304,7 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-is@17.0.2:
-    optional: true
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -17223,6 +17610,11 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   reflect.getprototypeof@1.0.6:
     dependencies:
       call-bind: 1.0.7
@@ -17423,6 +17815,10 @@ snapshots:
       is-regex: 1.1.4
 
   sax@1.3.0: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -17682,6 +18078,10 @@ snapshots:
 
   strip-final-newline@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
@@ -17756,6 +18156,8 @@ snapshots:
       supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tabbable@6.2.0: {}
 
@@ -17849,6 +18251,12 @@ snapshots:
 
   tinyspy@2.2.1: {}
 
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
   tmpl@1.0.5: {}
 
   to-fast-properties@2.0.0: {}
@@ -17859,7 +18267,15 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@1.3.0(typescript@5.8.3):
     dependencies:
@@ -17978,6 +18394,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici@6.24.1: {}
+
+  undici@7.25.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
@@ -18115,13 +18533,13 @@ snapshots:
       lightningcss: 1.32.0
       terser: 5.30.4
 
-  vitest-mock-extended@1.3.1(typescript@5.9.3)(vitest@1.6.0(@types/node@20.12.11)(lightningcss@1.32.0)(terser@5.30.4)):
+  vitest-mock-extended@1.3.1(typescript@5.9.3)(vitest@1.6.0(@types/node@20.12.11)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.30.4)):
     dependencies:
       ts-essentials: 9.4.2(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 1.6.0(@types/node@20.12.11)(lightningcss@1.32.0)(terser@5.30.4)
+      vitest: 1.6.0(@types/node@20.12.11)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.30.4)
 
-  vitest@1.6.0(@types/node@20.12.11)(lightningcss@1.32.0)(terser@5.30.4):
+  vitest@1.6.0(@types/node@20.12.11)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.30.4):
     dependencies:
       '@vitest/expect': 1.6.0
       '@vitest/runner': 1.6.0
@@ -18145,6 +18563,7 @@ snapshots:
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.12.11
+      jsdom: 29.0.2(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -18156,6 +18575,10 @@ snapshots:
       - terser
 
   vlq@1.0.1: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   walker@1.0.8:
     dependencies:
@@ -18171,15 +18594,27 @@ snapshots:
 
   webidl-conversions@5.0.0: {}
 
+  webidl-conversions@8.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
 
   whatwg-fetch@3.6.20: {}
+
+  whatwg-mimetype@5.0.0: {}
 
   whatwg-url-without-unicode@8.0.0-3:
     dependencies:
       buffer: 5.7.1
       punycode: 2.3.1
       webidl-conversions: 5.0.0
+
+  whatwg-url@16.0.1(@noble/hashes@2.0.1):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -18283,6 +18718,8 @@ snapshots:
       simple-plist: 1.3.1
       uuid: 7.0.3
 
+  xml-name-validator@5.0.0: {}
+
   xml2js@0.6.0:
     dependencies:
       sax: 1.3.0
@@ -18291,6 +18728,8 @@ snapshots:
   xmlbuilder@11.0.1: {}
 
   xmlbuilder@15.1.1: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -74,6 +74,8 @@
     "PORT",
     "SKIP_ENV_VALIDATION",
     "VITE_API_URL",
-    "WEB_URL"
+    "WEB_URL",
+    "MIGRATIONS_PATH",
+    "SENTRY_DSN_SERVER"
   ]
 }


### PR DESCRIPTION
## Summary

Browser-native Queue view for Fissa guests — replaces the deep-link redirect with a proper Queue layout that subsequent tasks will populate with live data.

## Tasks

- [x] Closes #57 — Replace auto-redirect with Queue view layout at /fissa/[pin]
- [ ] #59 — Fetch & render currently playing Track
- [ ] #61 — Render upcoming Tracks list (vote-ranked)
- [ ] #62 — Add polling (refetchInterval)
- [ ] #64 — Fissa-not-found / ended states
- [ ] #65 — Empty Queue state

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)