### PR TITLE
feat(web): pass Fissa PIN as callbackURL in Spotify OAuth sign-in

### DIFF
--- a/apps/web/src/components/SpotifySignInButton.tsx
+++ b/apps/web/src/components/SpotifySignInButton.tsx
@@ -1,6 +1,10 @@
 import { type FC } from "react";
 import { authClient } from "~/lib/auth-client";
 
+interface SpotifySignInButtonProps {
+  pin: string;
+}
+
 /**
  * SpotifySignInButton
  *
@@ -9,12 +13,12 @@ import { authClient } from "~/lib/auth-client";
  * - White text
  * - Spotify logo wordmark
  *
- * Calls authClient.signIn.social({ provider: "spotify" }) on click.
- * The callbackURL is handled by Task #60.
+ * Calls authClient.signIn.social({ provider: "spotify", callbackURL }) on click.
+ * callbackURL is set to /fissa/<pin> so the guest returns to the same Fissa after sign-in.
  */
-export const SpotifySignInButton: FC = () => {
+export const SpotifySignInButton: FC<SpotifySignInButtonProps> = ({ pin }) => {
   const handleSignIn = () => {
-    void authClient.signIn.social({ provider: "spotify" });
+    void authClient.signIn.social({ provider: "spotify", callbackURL: `/fissa/${pin}` });
   };
 
   return (

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -7,7 +7,7 @@
  * Scenario: Authenticated user does not see Sign in CTA (Task #58)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -76,9 +76,17 @@ vi.mock("~/lib/auth-client", () => ({
 }));
 
 vi.mock("~/components/SpotifySignInButton", () => ({
-  SpotifySignInButton: () => (
-    <button data-testid="spotify-signin-btn">Sign in with Spotify</button>
-  ),
+  SpotifySignInButton: ({ pin }: { pin: string }) => {
+    const { authClient: ac } = require("~/lib/auth-client") as { authClient: { signIn: { social: (opts: { provider: string; callbackURL: string }) => void } } };
+    return (
+      <button
+        data-testid="spotify-signin-btn"
+        onClick={() => ac.signIn.social({ provider: "spotify", callbackURL: `/fissa/${pin}` })}
+      >
+        Sign in with Spotify
+      </button>
+    );
+  },
 }));
 
 // ── Imports after mocks ────────────────────────────────────────────────────────
@@ -995,5 +1003,71 @@ describe("/fissa/$pin — Sign in with Spotify CTA (Task #58)", () => {
     render(<QueuePage pin="ABC123" />);
 
     expect(screen.queryByTestId("spotify-signin-btn")).not.toBeInTheDocument();
+  });
+});
+
+describe("/fissa/$pin — OAuth callbackURL (Task #60)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+  const mockSignInSocial = vi.mocked(authClient.signIn.social);
+
+  const activeFissaData = {
+    pin: "1234",
+    currentlyPlayingId: null,
+    tracks: [],
+  };
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: activeFissaData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+    mockSignInSocial.mockClear();
+  });
+
+  /**
+   * Scenario: Sign-in is initiated with correct callbackURL
+   *   Given an unauthenticated visitor on /fissa/1234
+   *   When they click "Sign in with Spotify"
+   *   Then signIn.social is called with callbackURL: "/fissa/1234"
+   */
+  it("calls signIn.social with callbackURL: /fissa/1234 when pin is 1234", () => {
+    render(<QueuePage pin="1234" />);
+
+    const btn = screen.getByTestId("spotify-signin-btn");
+    fireEvent.click(btn);
+
+    expect(mockSignInSocial).toHaveBeenCalledWith({
+      provider: "spotify",
+      callbackURL: "/fissa/1234",
+    });
+  });
+
+  /**
+   * Scenario: callbackURL includes the correct PIN from route params
+   *   Given an unauthenticated visitor on /fissa/9999
+   *   When they click "Sign in with Spotify"
+   *   Then signIn.social is called with callbackURL: "/fissa/9999"
+   */
+  it("calls signIn.social with callbackURL: /fissa/9999 when pin is 9999", () => {
+    mockUseQuery.mockReturnValue({
+      data: { ...activeFissaData, pin: "9999" },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="9999" />);
+
+    const btn = screen.getByTestId("spotify-signin-btn");
+    fireEvent.click(btn);
+
+    expect(mockSignInSocial).toHaveBeenCalledWith({
+      provider: "spotify",
+      callbackURL: "/fissa/9999",
+    });
   });
 });

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -102,7 +102,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
 
         {/* Unauthenticated sign-in CTA slot */}
         <section data-testid="queue-signin-cta" className="px-4 py-6">
-          {!sessionPending && !session?.user && <SpotifySignInButton />}
+          {!sessionPending && !session?.user && <SpotifySignInButton pin={pin} />}
         </section>
       </div>
     </Layout>


### PR DESCRIPTION
## Summary
- SpotifySignInButton now accepts a pin prop
- Passes callbackURL: /fissa/<pin> to better-auth signIn.social
- Guest returns to the same Fissa after sign-in

## Test plan
- [ ] signIn.social called with correct callbackURL for given pin

Closes #60

🤖 Generated with [Claude Code](https://claude.com/code)