### PR TITLE
feat(web): add Open in mobile app CTA with deep link

### DIFF
--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -792,6 +792,74 @@ describe("/fissa/$pin — No auto deep-link redirect on page load (Task #81)", (
   });
 });
 
+describe("/fissa/$pin — Open in mobile app CTA (Task #84)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: null,
+        tracks: [],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+  });
+
+  /**
+   * Scenario: Deep link href contains correct pin
+   *   Given a Fissa page with pin "ABC123"
+   *   Then there is an anchor with href="com.fissa://fissa/ABC123"
+   */
+  it("renders an anchor with the correct com.fissa deep-link href", () => {
+    render(<QueuePage pin="ABC123" />);
+
+    const cta = screen.getByTestId("open-mobile-app-cta");
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveAttribute("href", "com.fissa://fissa/ABC123");
+  });
+
+  /**
+   * Scenario: "Open in mobile app" CTA is visible on the page
+   */
+  it("shows 'Open in mobile app' text on the CTA", () => {
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByText(/open in mobile app/i)).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Guest taps without app installed — browser stays on page
+   *   The element must be a plain <a> tag (not a button), so the browser
+   *   handles the deep-link natively without JS navigation.
+   */
+  it("uses a plain <a> element (not a button) so the browser handles deep-link gracefully", () => {
+    render(<QueuePage pin="ABC123" />);
+
+    const cta = screen.getByTestId("open-mobile-app-cta");
+    expect(cta.tagName.toLowerCase()).toBe("a");
+  });
+
+  /**
+   * Deep link href is pin-specific — different pin produces different href
+   */
+  it("uses the pin prop in the deep-link href", () => {
+    mockUseQuery.mockReturnValue({
+      data: { pin: "XYZ999", currentlyPlayingId: null, tracks: [] },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="XYZ999" />);
+
+    const cta = screen.getByTestId("open-mobile-app-cta");
+    expect(cta).toHaveAttribute("href", "com.fissa://fissa/XYZ999");
+  });
+});
+
 describe("/fissa/$pin — Upcoming tracks list (Task #61)", () => {
   const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
 

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -98,8 +98,15 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
         </section>
 
         {/* Unauthenticated sign-in CTA slot */}
-        <section data-testid="queue-signin-cta" className="px-4 py-6">
+        <section data-testid="queue-signin-cta" className="flex flex-col items-center gap-3 px-4 py-6">
           {/* Placeholder — sign-in CTA wired in a later task */}
+          <a
+            href={`com.fissa://fissa/${pin}`}
+            data-testid="open-mobile-app-cta"
+            className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
+          >
+            Open in mobile app
+          </a>
         </section>
       </div>
     </Layout>


### PR DESCRIPTION
## Summary
- Adds <a href="com.fissa://fissa/<pin>"> CTA to Fissa page
- Uses plain anchor for native browser deep-link handling
- No JS navigation — browser handles app-not-installed gracefully

## Test plan
- [ ] CTA renders with correct deep-link href
- [ ] CTA is visible on the page

Closes #84

🤖 Generated with [Claude Code](https://claude.com/code)