### PR TITLE
feat(web): style app-open CTAs as visually secondary

### DIFF
--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -1020,3 +1020,43 @@ describe("/fissa/$pin — Open in desktop app placeholder CTA (Task #87)", () =>
     expect(cta.tagName.toLowerCase()).toBe("a");
   });
 });
+
+describe("/fissa/$pin — App-open CTAs visually secondary (Task #89)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: null,
+        tracks: [],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+  });
+
+  /**
+   * Scenario: Both app-open CTAs are present in the document
+   */
+  it("renders both app-open CTAs in the document", () => {
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("open-mobile-app-cta")).toBeInTheDocument();
+    expect(screen.getByTestId("open-desktop-app-cta")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Both CTAs share consistent styling
+   *   Both CTAs must have the same className to ensure visual consistency
+   */
+  it("applies identical className to both app-open CTAs for visual consistency", () => {
+    render(<QueuePage pin="ABC123" />);
+
+    const mobileCta = screen.getByTestId("open-mobile-app-cta");
+    const desktopCta = screen.getByTestId("open-desktop-app-cta");
+
+    expect(mobileCta.className).toBe(desktopCta.className);
+  });
+});

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -103,7 +103,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
           <a
             href={`com.fissa://fissa/${pin}`}
             data-testid="open-mobile-app-cta"
-            className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
+            className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
           >
             Open in mobile app
           </a>
@@ -112,7 +112,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
             href="#"
             data-testid="open-desktop-app-cta"
             onClick={(e) => e.preventDefault()}
-            className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
+            className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
           >
             Open in desktop app
           </a>


### PR DESCRIPTION
## Summary
- Applied secondary visual style to both "Open in mobile app" and "Open in desktop app" CTAs
- Uses existing design system pattern (consistent with web app components)
- Both CTAs share identical styling for visual consistency

## Test plan
- [ ] Both CTAs present in the document
- [ ] Consistent classes applied to both

Closes #89

🤖 Generated with [Claude Code](https://claude.com/code)