### PR TITLE
feat(web): handle OAuth cancellation and show dismissible error on Fissa page

### DIFF
--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -1131,3 +1131,41 @@ describe("/fissa/$pin — Queue interaction controls (Task #66)", () => {
     expect(screen.getByTestId("vote-controls")).toBeInTheDocument();
   });
 });
+
+describe("/fissa/$pin — OAuth error handling (Task #67)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({ data: { pin: "1234" }, isLoading: false, error: null } as any);
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+  });
+
+  it("shows error banner when error prop is present", () => {
+    render(<QueuePage pin="1234" error="access_denied" />);
+    expect(screen.getByTestId("oauth-error-banner")).toBeInTheDocument();
+    expect(screen.getByText(/Sign-in was cancelled or failed/)).toBeInTheDocument();
+  });
+
+  it("does not show error banner when no error prop", () => {
+    render(<QueuePage pin="1234" />);
+    expect(screen.queryByTestId("oauth-error-banner")).not.toBeInTheDocument();
+  });
+
+  it("sign-in button remains visible alongside the error banner", () => {
+    render(<QueuePage pin="1234" error="access_denied" />);
+    expect(screen.getByTestId("oauth-error-banner")).toBeInTheDocument();
+    expect(screen.getByTestId("spotify-signin-btn")).toBeInTheDocument();
+  });
+
+  it("dismiss button is present in the error banner", () => {
+    render(<QueuePage pin="1234" error="access_denied" />);
+    expect(screen.getByTestId("dismiss-error-btn")).toBeInTheDocument();
+  });
+
+  it("does not auto-trigger OAuth when error param is present", () => {
+    const mockSignIn = vi.mocked(authClient.signIn.social);
+    render(<QueuePage pin="1234" error="access_denied" />);
+    expect(mockSignIn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { type FC } from "react";
 import { CurrentlyPlayingTrack } from "~/components/CurrentlyPlayingTrack";
 import { Layout } from "~/components/Layout";
@@ -8,15 +8,21 @@ import { authClient } from "~/lib/auth-client";
 import { api } from "~/utils/api";
 
 export const Route = createFileRoute("/fissa/$pin")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    error: typeof search.error === "string" ? search.error : undefined,
+  }),
   component: JoinFissa,
 });
 
 interface QueuePageProps {
   pin: string;
+  error?: string;
 }
 
-export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
+export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
   const { data: session, isPending: sessionPending } = authClient.useSession();
+  const navigate = useNavigate({ from: "/fissa/$pin" });
+  const dismissError = () => void navigate({ to: "/fissa/$pin", params: { pin }, search: {} });
   const { data, isLoading, isError } = api.fissa.byId.useQuery(pin, {
     retry: false,
     enabled: !!pin,
@@ -100,6 +106,16 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
           )}
         </section>
 
+        {/* OAuth error banner */}
+        {error && (
+          <div data-testid="oauth-error-banner" role="alert" className="mx-4 my-2 flex items-center justify-between rounded border border-destructive bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            <span>Sign-in was cancelled or failed. Please try again.</span>
+            <button data-testid="dismiss-error-btn" onClick={dismissError} className="ml-4 text-xs underline" type="button">
+              Dismiss
+            </button>
+          </div>
+        )}
+
         {/* Unauthenticated sign-in CTA slot */}
         <section data-testid="queue-signin-cta" className="px-4 py-6">
           {!sessionPending && !session?.user && <SpotifySignInButton pin={pin} />}
@@ -121,5 +137,6 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
 
 function JoinFissa() {
   const { pin } = Route.useParams();
-  return <QueuePage pin={pin} />;
+  const { error } = Route.useSearch();
+  return <QueuePage pin={pin} error={error} />;
 }


### PR DESCRIPTION
## Summary
- Reads ?error= query param from URL on /fissa/<pin> via validateSearch
- Shows dismissible error banner when OAuth is cancelled or fails
- Guest stays signed out, no redirect loop, Sign in button remains for retry
- Error clears from URL on dismiss via useNavigate

## Test plan
- [ ] Error banner shown when ?error= param present
- [ ] Error dismissible via button
- [ ] Sign-in button still visible on error
- [ ] No auto-OAuth trigger when error param present

Closes #67

🤖 Generated with [Claude Code](https://claude.com/code)