### PR TITLE
feat(web): Party Guest can sign in with Spotify on Fissa page and return

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@trpc/client": "11.16.0",
     "@trpc/react-query": "11.16.0",
     "@trpc/server": "11.16.0",
+    "better-auth": "^1.2.7",
     "clsx": "^2.1.1",
     "framer-motion": "^11.5.6",
     "lucide-react": "^0.445.0",

--- a/apps/web/src/components/SpotifySignInButton.test.tsx
+++ b/apps/web/src/components/SpotifySignInButton.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Tests for SpotifySignInButton component (Task #63)
+ *
+ * Scenario: Successful OAuth redirects to Fissa page
+ * Scenario: Default redirect does not override callbackURL
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockSignInSocial = vi.fn();
+
+vi.mock("~/lib/auth-client", () => ({
+  authClient: {
+    useSession: vi.fn().mockReturnValue({ data: null, isPending: false }),
+    signIn: {
+      social: mockSignInSocial,
+    },
+  },
+}));
+
+// ── Imports after mocks ────────────────────────────────────────────────────────
+
+import { SpotifySignInButton } from "./SpotifySignInButton";
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("SpotifySignInButton — callbackURL flows to signIn.social (Task #63)", () => {
+  /**
+   * Scenario: Successful OAuth redirects to Fissa page
+   *   Given a SpotifySignInButton with pin="1234"
+   *   When the user clicks it
+   *   Then authClient.signIn.social is called with callbackURL: "/fissa/1234"
+   */
+  it("calls signIn.social with callbackURL='/fissa/1234' when pin='1234'", () => {
+    render(<SpotifySignInButton pin="1234" />);
+
+    fireEvent.click(screen.getByTestId("spotify-signin-btn"));
+
+    expect(mockSignInSocial).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "spotify",
+        callbackURL: "/fissa/1234",
+      }),
+    );
+  });
+
+  /**
+   * Scenario: Default redirect does not override callbackURL
+   *   Given a SpotifySignInButton with pin="1234"
+   *   When the user clicks it
+   *   Then callbackURL is "/fissa/1234" — not the homepage "/" or any other default
+   */
+  it("does not call signIn.social with callbackURL='/' (homepage default)", () => {
+    render(<SpotifySignInButton pin="1234" />);
+
+    fireEvent.click(screen.getByTestId("spotify-signin-btn"));
+
+    expect(mockSignInSocial).not.toHaveBeenCalledWith(
+      expect.objectContaining({ callbackURL: "/" }),
+    );
+    expect(mockSignInSocial).not.toHaveBeenCalledWith(
+      expect.objectContaining({ callbackURL: "" }),
+    );
+  });
+
+  /**
+   * Scenario: Different pin produces different callbackURL
+   *   Given a SpotifySignInButton with pin="9999"
+   *   When the user clicks it
+   *   Then callbackURL is "/fissa/9999"
+   */
+  it("calls signIn.social with callbackURL='/fissa/9999' when pin='9999'", () => {
+    render(<SpotifySignInButton pin="9999" />);
+
+    fireEvent.click(screen.getByTestId("spotify-signin-btn"));
+
+    expect(mockSignInSocial).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "spotify",
+        callbackURL: "/fissa/9999",
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/SpotifySignInButton.tsx
+++ b/apps/web/src/components/SpotifySignInButton.tsx
@@ -1,6 +1,10 @@
 import { type FC } from "react";
 import { authClient } from "~/lib/auth-client";
 
+interface SpotifySignInButtonProps {
+  pin: string;
+}
+
 /**
  * SpotifySignInButton
  *
@@ -9,12 +13,12 @@ import { authClient } from "~/lib/auth-client";
  * - White text
  * - Spotify logo wordmark
  *
- * Calls authClient.signIn.social({ provider: "spotify" }) on click.
- * The callbackURL is handled by Task #60.
+ * Calls authClient.signIn.social({ provider: "spotify", callbackURL }) on click.
+ * callbackURL is set to /fissa/<pin> so the guest returns to the same Fissa after sign-in.
  */
-export const SpotifySignInButton: FC = () => {
+export const SpotifySignInButton: FC<SpotifySignInButtonProps> = ({ pin }) => {
   const handleSignIn = () => {
-    void authClient.signIn.social({ provider: "spotify" });
+    void authClient.signIn.social({ provider: "spotify", callbackURL: `/fissa/${pin}` });
   };
 
   return (

--- a/apps/web/src/components/SpotifySignInButton.tsx
+++ b/apps/web/src/components/SpotifySignInButton.tsx
@@ -1,0 +1,41 @@
+import { type FC } from "react";
+import { authClient } from "~/lib/auth-client";
+
+/**
+ * SpotifySignInButton
+ *
+ * Renders a "Sign in with Spotify" button following Spotify brand guidelines:
+ * - Green (#1DB954) background
+ * - White text
+ * - Spotify logo wordmark
+ *
+ * Calls authClient.signIn.social({ provider: "spotify" }) on click.
+ * The callbackURL is handled by Task #60.
+ */
+export const SpotifySignInButton: FC = () => {
+  const handleSignIn = () => {
+    void authClient.signIn.social({ provider: "spotify" });
+  };
+
+  return (
+    <button
+      data-testid="spotify-signin-btn"
+      onClick={handleSignIn}
+      className="flex w-full items-center justify-center gap-3 rounded-full px-6 py-3 font-semibold text-white transition-opacity hover:opacity-90 active:opacity-80"
+      style={{ backgroundColor: "#1DB954" }}
+      type="button"
+    >
+      {/* Spotify wordmark SVG (official brand asset) */}
+      <svg
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-5 w-5 fill-white"
+        aria-label="Spotify"
+      >
+        <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+      </svg>
+      Sign in with Spotify
+    </button>
+  );
+};

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,0 +1,5 @@
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient({
+  baseURL: import.meta.env.VITE_API_URL ?? "http://localhost:3000",
+});

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -1,8 +1,10 @@
 /**
- * Tests for /fissa/$pin page (Task #57)
+ * Tests for /fissa/$pin page (Task #57, #58)
  *
  * Scenario: Fissa page renders layout without automatic redirect
  * Scenario: Visitor with native app installed is not auto-redirected
+ * Scenario: Unauthenticated visitor sees Sign in CTA (Task #58)
+ * Scenario: Authenticated user does not see Sign in CTA (Task #58)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
@@ -64,9 +66,25 @@ vi.mock("~/components/CurrentlyPlayingTrack", () => ({
     track ? <div data-testid="currently-playing-track">{track.trackId}</div> : null,
 }));
 
+vi.mock("~/lib/auth-client", () => ({
+  authClient: {
+    useSession: vi.fn().mockReturnValue({ data: null, isPending: false }),
+    signIn: {
+      social: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("~/components/SpotifySignInButton", () => ({
+  SpotifySignInButton: () => (
+    <button data-testid="spotify-signin-btn">Sign in with Spotify</button>
+  ),
+}));
+
 // ── Imports after mocks ────────────────────────────────────────────────────────
 
 import { api } from "~/utils/api";
+import { authClient } from "~/lib/auth-client";
 import { QueuePage } from "./$pin";
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
@@ -672,6 +690,126 @@ describe("/fissa/$pin — Auto-polling every 5 seconds (Task #62)", () => {
   });
 });
 
+describe("/fissa/$pin — No auto deep-link redirect on page load (Task #81)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+
+  beforeEach(() => {
+    // Reset window.location to a clean state
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "http://localhost/fissa/ABC123",
+        replace: vi.fn(),
+        assign: vi.fn(),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    } as any);
+  });
+
+  /**
+   * Scenario: Fissa page loads without auto-redirect
+   *   Given a guest navigates to /fissa/<pin>
+   *   When page finishes loading
+   *   Then browser remains on /fissa/<pin>
+   *   AND no deep-link redirect is triggered automatically
+   */
+  it("does not call window.location.replace on mount (no deep-link redirect)", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+
+  it("does not call window.location.href with a deep-link scheme on mount", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        pin: "ABC123",
+        currentlyPlayingId: null,
+        tracks: [],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    // href must stay on the page URL — never set to a deep-link
+    expect(window.location.href).not.toMatch(/^com\.fissa:\/\//);
+    expect(window.location.replace).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^com\.fissa:\/\//),
+    );
+  });
+
+  /**
+   * Scenario: Fissa page loads when native app is installed
+   *   Given a guest navigates to /fissa/<pin>
+   *   And the native app is installed
+   *   When page finishes loading
+   *   Then browser still remains on /fissa/<pin>
+   *   AND app is not launched automatically
+   */
+  it("does not redirect even when fissa data loads successfully (app installed simulation)", () => {
+    // Simulate query succeeding (as if native app is installed, data returns)
+    mockUseQuery.mockImplementation(
+      (_pin: string, options?: { onSuccess?: (data: unknown) => void }) => {
+        // Call onSuccess if it exists — prior code had redirect in onSuccess
+        options?.onSuccess?.({ pin: "ABC123" });
+        return {
+          data: { pin: "ABC123", currentlyPlayingId: null, tracks: [] },
+          isLoading: false,
+          isError: false,
+          error: null,
+        } as any;
+      },
+    );
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(window.location.replace).not.toHaveBeenCalled();
+    expect(window.location.assign).not.toHaveBeenCalled();
+    // href must not have been redirected to a native deep-link
+    expect(window.location.href).not.toMatch(/^com\.fissa:\/\//);
+  });
+
+  it("does not redirect to any deep-link scheme regardless of query state", () => {
+    // Test with multiple query states to ensure no state triggers a redirect
+    const states = [
+      { data: undefined, isLoading: true, isError: false, error: null },
+      { data: { pin: "ABC123", tracks: [] }, isLoading: false, isError: false, error: null },
+      { data: undefined, isLoading: false, isError: true, error: { message: "Not found" } },
+    ];
+
+    for (const state of states) {
+      // Reset replace mock between renders
+      const replaceSpy = vi.fn();
+      Object.defineProperty(window, "location", {
+        value: { href: "http://localhost/fissa/ABC123", replace: replaceSpy, assign: vi.fn() },
+        writable: true,
+        configurable: true,
+      });
+
+      mockUseQuery.mockReturnValue(state as any);
+      const { unmount } = render(<QueuePage pin="ABC123" />);
+
+      expect(replaceSpy).not.toHaveBeenCalled();
+      unmount();
+    }
+  });
+});
+
 describe("/fissa/$pin — Upcoming tracks list (Task #61)", () => {
   const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
 
@@ -782,5 +920,80 @@ describe("/fissa/$pin — Upcoming tracks list (Task #61)", () => {
     expect(items[0]).toHaveAttribute("data-trackid", "track-high");
     expect(items[1]).toHaveAttribute("data-trackid", "track-mid");
     expect(items[2]).toHaveAttribute("data-trackid", "track-low");
+  });
+});
+
+describe("/fissa/$pin — Sign in with Spotify CTA (Task #58)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+
+  const activeFissaData = {
+    pin: "ABC123",
+    currentlyPlayingId: null,
+    tracks: [],
+  };
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: activeFissaData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+  });
+
+  /**
+   * Scenario: Unauthenticated visitor sees Sign in CTA
+   *   Given visitor is not signed in
+   *   When they navigate to /fissa/<pin>
+   *   Then they see a "Sign in with Spotify" button
+   *   AND the Queue view is also visible
+   */
+  it("shows the Sign in with Spotify button when the visitor is unauthenticated", () => {
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("spotify-signin-btn")).toBeInTheDocument();
+  });
+
+  it("shows the queue sections alongside the sign-in CTA when unauthenticated", () => {
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("queue-now-playing")).toBeInTheDocument();
+    expect(screen.getByTestId("queue-signin-cta")).toBeInTheDocument();
+    expect(screen.getByTestId("spotify-signin-btn")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Authenticated user does not see Sign in CTA
+   *   Given visitor is signed in with Spotify
+   *   When they navigate to /fissa/<pin>
+   *   Then the "Sign in with Spotify" button is not visible
+   */
+  it("does not show the Sign in with Spotify button when the visitor is authenticated", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test" } },
+      isPending: false,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByTestId("spotify-signin-btn")).not.toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Session is loading — suppress CTA to avoid flash
+   *   Given session is still being determined (isPending: true)
+   *   Then the Sign in button is NOT shown yet
+   */
+  it("does not show the Sign in button while session is loading (isPending)", () => {
+    mockUseSession.mockReturnValue({ data: null, isPending: true } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByTestId("spotify-signin-btn")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -1131,3 +1131,41 @@ describe("/fissa/$pin — Queue interaction controls (Task #66)", () => {
     expect(screen.getByTestId("vote-controls")).toBeInTheDocument();
   });
 });
+
+describe("/fissa/$pin — OAuth error handling (Task #67)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({ data: { pin: "1234" }, isLoading: false, error: null } as any);
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+  });
+
+  it("shows error banner when error prop is present", () => {
+    render(<QueuePage pin="1234" error="access_denied" />);
+    expect(screen.getByTestId("oauth-error-banner")).toBeInTheDocument();
+    expect(screen.getByText(/Sign-in was cancelled or failed/)).toBeInTheDocument();
+  });
+
+  it("does not show error banner when no error prop", () => {
+    render(<QueuePage pin="1234" />);
+    expect(screen.queryByTestId("oauth-error-banner")).not.toBeInTheDocument();
+  });
+
+  it("sign-in button remains visible alongside the error banner", () => {
+    render(<QueuePage pin="1234" error="access_denied" />);
+    expect(screen.getByTestId("oauth-error-banner")).toBeInTheDocument();
+    expect(screen.getByTestId("spotify-signin-btn")).toBeInTheDocument();
+  });
+
+  it("dismiss button is present in the error banner", () => {
+    render(<QueuePage pin="1234" error="access_denied" />);
+    expect(screen.getByTestId("dismiss-error-btn")).toBeInTheDocument();
+  });
+
+  it("does not auto-trigger OAuth when error param is present", () => {
+    const mockSignIn = vi.mocked(authClient.signIn.social);
+    render(<QueuePage pin="1234" error="access_denied" />);
+    expect(mockSignIn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -7,7 +7,7 @@
  * Scenario: Authenticated user does not see Sign in CTA (Task #58)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -76,9 +76,17 @@ vi.mock("~/lib/auth-client", () => ({
 }));
 
 vi.mock("~/components/SpotifySignInButton", () => ({
-  SpotifySignInButton: () => (
-    <button data-testid="spotify-signin-btn">Sign in with Spotify</button>
-  ),
+  SpotifySignInButton: ({ pin }: { pin: string }) => {
+    const { authClient: ac } = require("~/lib/auth-client") as { authClient: { signIn: { social: (opts: { provider: string; callbackURL: string }) => void } } };
+    return (
+      <button
+        data-testid="spotify-signin-btn"
+        onClick={() => ac.signIn.social({ provider: "spotify", callbackURL: `/fissa/${pin}` })}
+      >
+        Sign in with Spotify
+      </button>
+    );
+  },
 }));
 
 // ── Imports after mocks ────────────────────────────────────────────────────────
@@ -995,5 +1003,71 @@ describe("/fissa/$pin — Sign in with Spotify CTA (Task #58)", () => {
     render(<QueuePage pin="ABC123" />);
 
     expect(screen.queryByTestId("spotify-signin-btn")).not.toBeInTheDocument();
+  });
+});
+
+describe("/fissa/$pin — OAuth callbackURL (Task #60)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+  const mockSignInSocial = vi.mocked(authClient.signIn.social);
+
+  const activeFissaData = {
+    pin: "1234",
+    currentlyPlayingId: null,
+    tracks: [],
+  };
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: activeFissaData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+    mockSignInSocial.mockClear();
+  });
+
+  /**
+   * Scenario: Sign-in is initiated with correct callbackURL
+   *   Given an unauthenticated visitor on /fissa/1234
+   *   When they click "Sign in with Spotify"
+   *   Then signIn.social is called with callbackURL: "/fissa/1234"
+   */
+  it("calls signIn.social with callbackURL: /fissa/1234 when pin is 1234", () => {
+    render(<QueuePage pin="1234" />);
+
+    const btn = screen.getByTestId("spotify-signin-btn");
+    fireEvent.click(btn);
+
+    expect(mockSignInSocial).toHaveBeenCalledWith({
+      provider: "spotify",
+      callbackURL: "/fissa/1234",
+    });
+  });
+
+  /**
+   * Scenario: callbackURL includes the correct PIN from route params
+   *   Given an unauthenticated visitor on /fissa/9999
+   *   When they click "Sign in with Spotify"
+   *   Then signIn.social is called with callbackURL: "/fissa/9999"
+   */
+  it("calls signIn.social with callbackURL: /fissa/9999 when pin is 9999", () => {
+    mockUseQuery.mockReturnValue({
+      data: { ...activeFissaData, pin: "9999" },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(<QueuePage pin="9999" />);
+
+    const btn = screen.getByTestId("spotify-signin-btn");
+    fireEvent.click(btn);
+
+    expect(mockSignInSocial).toHaveBeenCalledWith({
+      provider: "spotify",
+      callbackURL: "/fissa/9999",
+    });
   });
 });

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -7,7 +7,7 @@
  * Scenario: Authenticated user does not see Sign in CTA (Task #58)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -76,17 +76,11 @@ vi.mock("~/lib/auth-client", () => ({
 }));
 
 vi.mock("~/components/SpotifySignInButton", () => ({
-  SpotifySignInButton: ({ pin }: { pin: string }) => {
-    const { authClient: ac } = require("~/lib/auth-client") as { authClient: { signIn: { social: (opts: { provider: string; callbackURL: string }) => void } } };
-    return (
-      <button
-        data-testid="spotify-signin-btn"
-        onClick={() => ac.signIn.social({ provider: "spotify", callbackURL: `/fissa/${pin}` })}
-      >
-        Sign in with Spotify
-      </button>
-    );
-  },
+  SpotifySignInButton: ({ pin }: { pin: string }) => (
+    <button data-testid="spotify-signin-btn" data-pin={pin}>
+      Sign in with Spotify
+    </button>
+  ),
 }));
 
 // ── Imports after mocks ────────────────────────────────────────────────────────
@@ -1009,7 +1003,6 @@ describe("/fissa/$pin — Sign in with Spotify CTA (Task #58)", () => {
 describe("/fissa/$pin — OAuth callbackURL (Task #60)", () => {
   const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
   const mockUseSession = vi.mocked(authClient.useSession);
-  const mockSignInSocial = vi.mocked(authClient.signIn.social);
 
   const activeFissaData = {
     pin: "1234",
@@ -1025,25 +1018,18 @@ describe("/fissa/$pin — OAuth callbackURL (Task #60)", () => {
       error: null,
     } as any);
     mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
-    mockSignInSocial.mockClear();
   });
 
   /**
    * Scenario: Sign-in is initiated with correct callbackURL
    *   Given an unauthenticated visitor on /fissa/1234
-   *   When they click "Sign in with Spotify"
-   *   Then signIn.social is called with callbackURL: "/fissa/1234"
+   *   Then SpotifySignInButton receives pin="1234" so it can build callbackURL: "/fissa/1234"
    */
-  it("calls signIn.social with callbackURL: /fissa/1234 when pin is 1234", () => {
+  it("passes pin='1234' to SpotifySignInButton so callbackURL resolves to /fissa/1234", () => {
     render(<QueuePage pin="1234" />);
 
     const btn = screen.getByTestId("spotify-signin-btn");
-    fireEvent.click(btn);
-
-    expect(mockSignInSocial).toHaveBeenCalledWith({
-      provider: "spotify",
-      callbackURL: "/fissa/1234",
-    });
+    expect(btn).toHaveAttribute("data-pin", "1234");
   });
 
   /**
@@ -1052,7 +1038,7 @@ describe("/fissa/$pin — OAuth callbackURL (Task #60)", () => {
    *   When they click "Sign in with Spotify"
    *   Then signIn.social is called with callbackURL: "/fissa/9999"
    */
-  it("calls signIn.social with callbackURL: /fissa/9999 when pin is 9999", () => {
+  it("passes pin='9999' to SpotifySignInButton so callbackURL resolves to /fissa/9999", () => {
     mockUseQuery.mockReturnValue({
       data: { ...activeFissaData, pin: "9999" },
       isLoading: false,
@@ -1063,11 +1049,85 @@ describe("/fissa/$pin — OAuth callbackURL (Task #60)", () => {
     render(<QueuePage pin="9999" />);
 
     const btn = screen.getByTestId("spotify-signin-btn");
-    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("data-pin", "9999");
+  });
+});
 
-    expect(mockSignInSocial).toHaveBeenCalledWith({
-      provider: "spotify",
-      callbackURL: "/fissa/9999",
-    });
+describe("/fissa/$pin — Queue interaction controls (Task #66)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+
+  const activeFissaData = {
+    pin: "1234",
+    currentlyPlayingId: null,
+    tracks: [],
+  };
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: activeFissaData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+  });
+
+  /**
+   * Scenario: Authenticated guest sees interaction controls
+   *   Given a visitor who is signed in with Spotify
+   *   When they navigate to /fissa/<pin>
+   *   Then they see an "Add Track" button and vote controls
+   */
+  it("shows Add Track button and vote controls when the visitor is authenticated", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test User" } },
+      isPending: false,
+    } as any);
+
+    render(<QueuePage pin="1234" />);
+
+    expect(screen.getByTestId("add-track-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("vote-controls")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Unauthenticated visitor does not see interaction controls
+   *   Given a visitor who is not signed in
+   *   When they navigate to /fissa/<pin>
+   *   Then they do NOT see the Add Track button or vote controls
+   */
+  it("does not show Add Track button or vote controls when the visitor is unauthenticated", () => {
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+
+    render(<QueuePage pin="1234" />);
+
+    expect(screen.queryByTestId("add-track-btn")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("vote-controls")).not.toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Controls become visible after sign-in without page reload
+   *   Given a visitor who starts unauthenticated
+   *   When the session updates to authenticated
+   *   Then the controls appear without a page reload
+   */
+  it("controls appear after sign-in (session update without page reload)", () => {
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+
+    const { rerender } = render(<QueuePage pin="1234" />);
+
+    expect(screen.queryByTestId("add-track-btn")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("vote-controls")).not.toBeInTheDocument();
+
+    // Simulate session becoming available (user signs in)
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test User" } },
+      isPending: false,
+    } as any);
+
+    rerender(<QueuePage pin="1234" />);
+
+    expect(screen.getByTestId("add-track-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("vote-controls")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { type FC } from "react";
 import { CurrentlyPlayingTrack } from "~/components/CurrentlyPlayingTrack";
 import { Layout } from "~/components/Layout";
@@ -8,15 +8,21 @@ import { authClient } from "~/lib/auth-client";
 import { api } from "~/utils/api";
 
 export const Route = createFileRoute("/fissa/$pin")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    error: typeof search.error === "string" ? search.error : undefined,
+  }),
   component: JoinFissa,
 });
 
 interface QueuePageProps {
   pin: string;
+  error?: string;
 }
 
-export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
+export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
   const { data: session, isPending: sessionPending } = authClient.useSession();
+  const navigate = useNavigate({ from: "/fissa/$pin" });
+  const dismissError = () => void navigate({ to: "/fissa/$pin", params: { pin }, search: {} });
   const { data, isLoading, isError } = api.fissa.byId.useQuery(pin, {
     retry: false,
     enabled: !!pin,
@@ -100,6 +106,16 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
           )}
         </section>
 
+        {/* OAuth error banner */}
+        {error && (
+          <div data-testid="oauth-error-banner" role="alert" className="mx-4 my-2 flex items-center justify-between rounded border border-destructive bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            <span>Sign-in was cancelled or failed. Please try again.</span>
+            <button data-testid="dismiss-error-btn" onClick={dismissError} className="ml-4 text-xs underline" type="button">
+              Dismiss
+            </button>
+          </div>
+        )}
+
         {/* Unauthenticated sign-in CTA slot */}
         <section data-testid="queue-signin-cta" className="px-4 py-6">
           {!sessionPending && !session?.user && <SpotifySignInButton pin={pin} />}
@@ -121,5 +137,6 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
 
 function JoinFissa() {
   const { pin } = Route.useParams();
-  return <QueuePage pin={pin} />;
+  const { error } = Route.useSearch();
+  return <QueuePage pin={pin} error={error} />;
 }

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -102,7 +102,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
 
         {/* Unauthenticated sign-in CTA slot */}
         <section data-testid="queue-signin-cta" className="px-4 py-6">
-          {!sessionPending && !session?.user && <SpotifySignInButton />}
+          {!sessionPending && !session?.user && <SpotifySignInButton pin={pin} />}
         </section>
       </div>
     </Layout>

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -104,6 +104,16 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
         <section data-testid="queue-signin-cta" className="px-4 py-6">
           {!sessionPending && !session?.user && <SpotifySignInButton pin={pin} />}
         </section>
+
+        {/* Queue interaction controls — visible only for authenticated guests */}
+        {session?.user && (
+          <section data-testid="queue-interaction-controls" className="px-4 py-4">
+            <button data-testid="add-track-btn" className="w-full rounded-full bg-primary px-6 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90" type="button">
+              Add Track
+            </button>
+            <div data-testid="vote-controls">{/* Vote controls — Feature #47 */}</div>
+          </section>
+        )}
       </div>
     </Layout>
   );

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -3,6 +3,8 @@ import { type FC } from "react";
 import { CurrentlyPlayingTrack } from "~/components/CurrentlyPlayingTrack";
 import { Layout } from "~/components/Layout";
 import { QueueTrackList } from "~/components/QueueTrackList";
+import { SpotifySignInButton } from "~/components/SpotifySignInButton";
+import { authClient } from "~/lib/auth-client";
 import { api } from "~/utils/api";
 
 export const Route = createFileRoute("/fissa/$pin")({
@@ -14,6 +16,7 @@ interface QueuePageProps {
 }
 
 export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
+  const { data: session, isPending: sessionPending } = authClient.useSession();
   const { data, isLoading, isError } = api.fissa.byId.useQuery(pin, {
     retry: false,
     enabled: !!pin,
@@ -99,7 +102,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin }) => {
 
         {/* Unauthenticated sign-in CTA slot */}
         <section data-testid="queue-signin-cta" className="px-4 py-6">
-          {/* Placeholder — sign-in CTA wired in a later task */}
+          {!sessionPending && !session?.user && <SpotifySignInButton />}
         </section>
       </div>
     </Layout>

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
   resolve: {
     alias: {
       "~": path.resolve(__dirname, "./src"),
-      react: path.resolve(__dirname, "./node_modules/react"),
-      "react-dom": path.resolve(__dirname, "./node_modules/react-dom"),
+      react: path.resolve(__dirname, "../../node_modules/react"),
+      "react-dom": path.resolve(__dirname, "../../node_modules/react-dom"),
     },
     dedupe: ["react", "react-dom"],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       '@trpc/server':
         specifier: 11.16.0
         version: 11.16.0(typescript@5.8.3)
+      better-auth:
+        specifier: ^1.2.7
+        version: 1.6.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0))(prisma@5.13.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vitest@1.6.0(@types/node@20.12.11)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.30.4))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -10084,11 +10087,18 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.5(zod@4.3.6)
+      better-call: 1.3.5(zod@3.23.8)
       jose: 6.2.2
       kysely: 0.28.15
       nanostores: 1.2.0
       zod: 4.3.6
+
+  '@better-auth/drizzle-adapter@1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0))':
+    dependencies:
+      '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
+    optionalDependencies:
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0)
 
   '@better-auth/drizzle-adapter@1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0))':
     dependencies:
@@ -10496,6 +10506,83 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.0.1
 
+  ? '@expo/cli@54.0.23(expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@18.2.15)(@types/react@18.2.37)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@18.2.0(react@18.2.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-reanimated@4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(typescript@5.8.3)'
+  : dependencies:
+      '@0no-co/graphql.web': 1.2.0(graphql@15.8.0)
+      '@expo/code-signing-certificates': 0.0.6
+      '@expo/config': 12.0.13
+      '@expo/config-plugins': 54.0.4
+      '@expo/devcert': 1.2.1
+      '@expo/env': 2.0.11
+      '@expo/image-utils': 0.8.13(typescript@5.8.3)
+      '@expo/json-file': 10.0.13
+      '@expo/metro': 54.2.0
+      '@expo/metro-config': 54.0.14(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))
+      '@expo/osascript': 2.4.2
+      '@expo/package-manager': 1.10.4
+      '@expo/plist': 0.4.8
+      '@expo/prebuild-config': 54.0.8(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(typescript@5.8.3)
+      '@expo/schema-utils': 0.1.8
+      '@expo/spawn-async': 1.7.2
+      '@expo/ws-tunnel': 1.0.6
+      '@expo/xcpretty': 4.3.1
+      '@react-native/dev-middleware': 0.81.5
+      '@urql/core': 5.2.0(graphql@15.8.0)
+      '@urql/exchange-retry': 1.3.2(@urql/core@5.2.0(graphql@15.8.0))
+      accepts: 1.3.8
+      arg: 5.0.2
+      better-opn: 3.0.2
+      bplist-creator: 0.1.0
+      bplist-parser: 0.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      compression: 1.7.4
+      connect: 3.7.0
+      debug: 4.4.3
+      env-editor: 0.4.2
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      expo-server: 1.0.5
+      freeport-async: 2.0.0
+      getenv: 2.0.0
+      glob: 13.0.6
+      lan-network: 0.1.7
+      minimatch: 9.0.4
+      node-forge: 1.4.0
+      npm-package-arg: 11.0.3
+      ora: 3.4.0
+      picomatch: 3.0.1
+      pretty-bytes: 5.6.0
+      pretty-format: 29.7.0
+      progress: 2.0.3
+      prompts: 2.4.2
+      qrcode-terminal: 0.11.0
+      require-from-string: 2.0.2
+      requireg: 0.2.2
+      resolve: 1.22.11
+      resolve-from: 5.0.0
+      resolve.exports: 2.0.3
+      semver: 7.7.4
+      send: 0.19.2
+      slugify: 1.6.6
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.10
+      structured-headers: 0.4.1
+      tar: 7.5.13
+      terminal-link: 2.1.1
+      undici: 6.24.1
+      wrap-ansi: 7.0.0
+      ws: 8.17.0
+    optionalDependencies:
+      expo-router: 6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@18.2.15)(@types/react@18.2.37)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@18.2.0(react@18.2.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-reanimated@4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - graphql
+      - supports-color
+      - typescript
+      - utf-8-validate
+    optional: true
+
   ? '@expo/cli@54.0.23(expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@18.2.15)(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-reanimated@4.1.7(react-native-worklets@0.8.1(@babel/core@7.26.10)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo@54.0.33(@babel/core@7.26.10)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)'
   : dependencies:
       '@0no-co/graphql.web': 1.2.0(graphql@15.8.0)
@@ -10706,6 +10793,14 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0)
 
+  '@expo/devtools@0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      chalk: 4.1.2
+    optionalDependencies:
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    optional: true
+
   '@expo/devtools@0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       chalk: 4.1.2
@@ -10802,6 +10897,37 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@expo/metro-config@54.0.14(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.26.10
+      '@babel/generator': 7.29.1
+      '@expo/config': 12.0.13
+      '@expo/env': 2.0.11
+      '@expo/json-file': 10.0.13
+      '@expo/metro': 54.2.0
+      '@expo/spawn-async': 1.7.2
+      browserslist: 4.28.2
+      chalk: 4.1.2
+      debug: 4.4.3
+      dotenv: 16.4.5
+      dotenv-expand: 11.0.6
+      getenv: 2.0.0
+      glob: 13.0.6
+      hermes-parser: 0.29.1
+      jsc-safe-url: 0.2.4
+      lightningcss: 1.30.1
+      minimatch: 9.0.4
+      postcss: 8.4.49
+      resolve-from: 5.0.0
+    optionalDependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    optional: true
+
   '@expo/metro-config@54.0.14(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -10831,6 +10957,19 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
+
+  '@expo/metro-runtime@6.1.2(expo@54.0.33)(react-dom@18.2.0(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      anser: 1.4.10
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      pretty-format: 29.7.0
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+      stacktrace-parser: 0.1.10
+      whatwg-fetch: 3.6.20
+    optionalDependencies:
+      react-dom: 18.2.0(react@18.2.0)
     optional: true
 
   '@expo/metro-runtime@6.1.2(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
@@ -10915,6 +11054,24 @@ snapshots:
       - supports-color
       - typescript
 
+  '@expo/prebuild-config@54.0.8(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(typescript@5.8.3)':
+    dependencies:
+      '@expo/config': 12.0.13
+      '@expo/config-plugins': 54.0.4
+      '@expo/config-types': 54.0.10
+      '@expo/image-utils': 0.8.13(typescript@5.8.3)
+      '@expo/json-file': 10.0.13
+      '@react-native/normalize-colors': 0.81.5
+      debug: 4.4.3
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      resolve-from: 5.0.0
+      semver: 7.7.4
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    optional: true
+
   '@expo/prebuild-config@54.0.8(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
       '@expo/config': 12.0.13
@@ -10969,6 +11126,13 @@ snapshots:
       expo-font: 14.0.11(expo@54.0.33(@babel/core@7.26.10)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0)
+
+  '@expo/vector-icons@15.1.1(expo-font@14.0.11(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      expo-font: 14.0.11(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    optional: true
 
   '@expo/vector-icons@15.1.1(expo-font@14.0.11(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -11557,6 +11721,19 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 18.2.15
+    optional: true
+
   '@radix-ui/react-collection@1.1.7(@types/react-dom@18.2.15)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
@@ -11569,17 +11746,54 @@ snapshots:
       '@types/react': 19.1.17
       '@types/react-dom': 18.2.15
 
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.2.37)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
 
+  '@radix-ui/react-context@1.1.2(@types/react@18.2.37)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
+
   '@radix-ui/react-context@1.1.2(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.2.37)(react@18.2.0)
+      aria-hidden: 1.2.6
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.7.2(@types/react@18.2.37)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 18.2.15
+    optional: true
 
   '@radix-ui/react-dialog@1.1.15(@types/react-dom@18.2.15)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -11603,11 +11817,32 @@ snapshots:
       '@types/react': 19.1.17
       '@types/react-dom': 18.2.15
 
+  '@radix-ui/react-direction@1.1.1(@types/react@18.2.37)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 18.2.15
+    optional: true
 
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.2.15)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -11622,11 +11857,30 @@ snapshots:
       '@types/react': 19.1.17
       '@types/react-dom': 18.2.15
 
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@18.2.37)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 18.2.15
+    optional: true
 
   '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.2.15)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -11639,12 +11893,31 @@ snapshots:
       '@types/react': 19.1.17
       '@types/react-dom': 18.2.15
 
+  '@radix-ui/react-id@1.1.1(@types/react@18.2.37)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
+
   '@radix-ui/react-id@1.1.1(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 18.2.15
+    optional: true
 
   '@radix-ui/react-portal@1.1.9(@types/react-dom@18.2.15)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -11656,6 +11929,17 @@ snapshots:
       '@types/react': 19.1.17
       '@types/react-dom': 18.2.15
 
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 18.2.15
+    optional: true
+
   '@radix-ui/react-presence@1.1.5(@types/react-dom@18.2.15)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
@@ -11666,6 +11950,16 @@ snapshots:
       '@types/react': 19.1.17
       '@types/react-dom': 18.2.15
 
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 18.2.15
+    optional: true
+
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.2.15)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.17)(react@19.1.0)
@@ -11674,6 +11968,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
       '@types/react-dom': 18.2.15
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 18.2.15
+    optional: true
 
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@18.2.15)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -11692,6 +12004,14 @@ snapshots:
       '@types/react': 19.1.17
       '@types/react-dom': 18.2.15
 
+  '@radix-ui/react-slot@1.2.0(@types/react@18.2.37)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
+
   '@radix-ui/react-slot@1.2.0(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
@@ -11699,12 +12019,37 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
 
+  '@radix-ui/react-slot@1.2.3(@types/react@18.2.37)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 18.2.15
+    optional: true
 
   '@radix-ui/react-tabs@1.1.13(@types/react-dom@18.2.15)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -11722,11 +12067,27 @@ snapshots:
       '@types/react': 19.1.17
       '@types/react-dom': 18.2.15
 
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.2.37)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.2.37)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
 
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
@@ -11736,6 +12097,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
 
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.2.37)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
@@ -11743,12 +12112,27 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
 
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.2.37)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.2.37)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
+
   '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.17)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.2.37)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
@@ -12311,6 +12695,16 @@ snapshots:
 
   '@react-native/normalize-colors@0.81.5': {}
 
+  '@react-native/virtualized-lists@0.81.5(@types/react@18.2.37)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
+
   '@react-native/virtualized-lists@0.81.5(@types/react@19.1.17)(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       invariant: 2.2.4
@@ -12343,6 +12737,20 @@ snapshots:
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
+  '@react-navigation/bottom-tabs@7.15.9(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/elements': 2.9.14(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      color: 4.2.3
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      sf-symbols-typescript: 2.2.0
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+    optional: true
+
   '@react-navigation/bottom-tabs@7.15.9(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@react-navigation/elements': 2.9.14(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -12355,6 +12763,19 @@ snapshots:
       sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
+    optional: true
+
+  '@react-navigation/core@7.17.2(react@18.2.0)':
+    dependencies:
+      '@react-navigation/routers': 7.5.3
+      escape-string-regexp: 4.0.0
+      fast-deep-equal: 3.1.3
+      nanoid: 3.3.11
+      query-string: 7.1.3
+      react: 18.2.0
+      react-is: 19.2.5
+      use-latest-callback: 0.2.6(react@18.2.0)
+      use-sync-external-store: 1.6.0(react@18.2.0)
     optional: true
 
   '@react-navigation/core@7.17.2(react@19.1.0)':
@@ -12378,6 +12799,17 @@ snapshots:
       react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       use-latest-callback: 0.2.6(react@19.1.0)
       use-sync-external-store: 1.6.0(react@19.1.0)
+
+  '@react-navigation/elements@2.9.14(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      color: 4.2.3
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      use-latest-callback: 0.2.6(react@18.2.0)
+      use-sync-external-store: 1.6.0(react@18.2.0)
+    optional: true
 
   '@react-navigation/elements@2.9.14(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -12404,6 +12836,21 @@ snapshots:
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
+  '@react-navigation/native-stack@7.14.10(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/elements': 2.9.14(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      color: 4.2.3
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      sf-symbols-typescript: 2.2.0
+      warn-once: 0.1.1
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+    optional: true
+
   '@react-navigation/native-stack@7.14.10(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@react-navigation/elements': 2.9.14(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -12428,6 +12875,17 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0)
       use-latest-callback: 0.2.6(react@19.1.0)
+
+  '@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/core': 7.17.2(react@18.2.0)
+      escape-string-regexp: 4.0.0
+      fast-deep-equal: 3.1.3
+      nanoid: 3.3.11
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+      use-latest-callback: 0.2.6(react@18.2.0)
+    optional: true
 
   '@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -13803,6 +14261,39 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  babel-preset-expo@54.0.10(@babel/core@7.29.0)(@babel/runtime@7.26.10)(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-refresh@0.14.2):
+    dependencies:
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.29.0)
+      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-export-default-from': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
+      '@babel/preset-react': 7.24.1(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.24.1(@babel/core@7.29.0)
+      '@react-native/babel-preset': 0.81.5(@babel/core@7.29.0)
+      babel-plugin-react-compiler: 1.0.0
+      babel-plugin-react-native-web: 0.21.2
+      babel-plugin-syntax-hermes-parser: 0.29.1
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
+      debug: 4.4.3
+      react-refresh: 0.14.2
+      resolve-from: 5.0.0
+    optionalDependencies:
+      '@babel/runtime': 7.26.10
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    optional: true
+
   babel-preset-expo@54.0.10(@babel/core@7.29.0)(@babel/runtime@7.26.10)(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-refresh@0.14.2):
     dependencies:
       '@babel/helper-module-imports': 7.28.6
@@ -13859,6 +14350,37 @@ snapshots:
 
   baseline-browser-mapping@2.10.17: {}
 
+  better-auth@1.6.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0))(prisma@5.13.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vitest@1.6.0(@types/node@20.12.11)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.30.4)):
+    dependencies:
+      '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0))
+      '@better-auth/kysely-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.15)
+      '@better-auth/memory-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
+      '@better-auth/prisma-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@prisma/client@5.13.0(prisma@5.13.0))(prisma@5.13.0)
+      '@better-auth/telemetry': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
+      '@noble/ciphers': 2.1.1
+      '@noble/hashes': 2.0.1
+      better-call: 1.3.5(zod@3.23.8)
+      defu: 6.1.7
+      jose: 6.2.2
+      kysely: 0.28.15
+      nanostores: 1.2.0
+      zod: 4.3.6
+    optionalDependencies:
+      '@prisma/client': 5.13.0(prisma@5.13.0)
+      drizzle-kit: 0.31.10
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0)
+      prisma: 5.13.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      vitest: 1.6.0(@types/node@20.12.11)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.30.4)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
   better-auth@1.6.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0))(prisma@5.13.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@1.6.0(@types/node@20.12.11)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.30.4)):
     dependencies:
       '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
@@ -13889,6 +14411,15 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
+
+  better-call@1.3.5(zod@3.23.8):
+    dependencies:
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.0
+    optionalDependencies:
+      zod: 3.23.8
 
   better-call@1.3.5(zod@4.3.6):
     dependencies:
@@ -14414,6 +14945,17 @@ snapshots:
       '@esbuild-kit/esm-loader': 2.6.5
       esbuild: 0.25.12
       tsx: 4.21.0
+
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0):
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@prisma/client': 5.13.0(prisma@5.13.0)
+      '@types/pg': 8.15.6
+      expo-sqlite: 16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      kysely: 0.28.15
+      postgres: 3.4.9
+      prisma: 5.13.0
+    optional: true
 
   drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@5.13.0(prisma@5.13.0))(@types/pg@8.15.6)(expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(kysely@0.28.15)(postgres@3.4.9)(prisma@5.13.0):
     optionalDependencies:
@@ -14955,6 +15497,18 @@ snapshots:
       - supports-color
       - typescript
 
+  expo-asset@12.0.12(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3):
+    dependencies:
+      '@expo/image-utils': 0.8.13(typescript@5.8.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      expo-constants: 18.0.13(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    optional: true
+
   expo-asset@12.0.12(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3):
     dependencies:
       '@expo/image-utils': 0.8.13(typescript@5.8.3)
@@ -14990,6 +15544,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-constants@18.0.13(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)):
+    dependencies:
+      '@expo/config': 12.0.13
+      '@expo/env': 2.0.11
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   expo-constants@18.0.13(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       '@expo/config': 12.0.13
@@ -15017,6 +15581,12 @@ snapshots:
       expo: 54.0.33(@babel/core@7.26.10)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react-native: 0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0)
 
+  expo-file-system@19.0.21(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    optional: true
+
   expo-file-system@19.0.21(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
@@ -15029,6 +15599,14 @@ snapshots:
       fontfaceobserver: 2.3.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0)
+
+  expo-font@14.0.11(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      fontfaceobserver: 2.3.0
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    optional: true
 
   expo-font@14.0.11(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -15055,6 +15633,12 @@ snapshots:
       expo: 54.0.33(@babel/core@7.26.10)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
 
+  expo-keep-awake@15.0.8(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react@18.2.0):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      react: 18.2.0
+    optional: true
+
   expo-keep-awake@15.0.8(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react@19.1.0):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
@@ -15076,6 +15660,17 @@ snapshots:
     transitivePeerDependencies:
       - expo
       - supports-color
+
+  expo-linking@8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      expo-constants: 18.0.13(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))
+      invariant: 2.2.4
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    transitivePeerDependencies:
+      - expo
+      - supports-color
+    optional: true
 
   expo-linking@8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -15110,6 +15705,13 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0)
 
+  expo-modules-core@3.0.29(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      invariant: 2.2.4
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    optional: true
+
   expo-modules-core@3.0.29(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       invariant: 2.2.4
@@ -15132,6 +15734,49 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  ? expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@18.2.15)(@types/react@18.2.37)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@18.2.0(react@18.2.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-reanimated@4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+  : dependencies:
+      '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@18.2.0(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      '@expo/schema-utils': 0.1.8
+      '@radix-ui/react-slot': 1.2.0(@types/react@18.2.37)(react@18.2.0)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-navigation/bottom-tabs': 7.15.9(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native-stack': 7.14.10(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      client-only: 0.0.1
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      expo-constants: 18.0.13(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))
+      expo-linking: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      expo-server: 1.0.5
+      fast-deep-equal: 3.1.3
+      invariant: 2.2.4
+      nanoid: 3.3.11
+      query-string: 7.1.3
+      react: 18.2.0
+      react-fast-compare: 3.2.2
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      semver: 7.6.3
+      server-only: 0.0.1
+      sf-symbols-typescript: 2.2.0
+      shallowequal: 1.1.0
+      use-latest-callback: 0.2.6(react@18.2.0)
+      vaul: 1.1.2(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    optionalDependencies:
+      react-dom: 18.2.0(react@18.2.0)
+      react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      react-native-reanimated: 4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+    optional: true
 
   ? expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@18.2.15)(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-reanimated@4.1.7(react-native-worklets@0.8.1(@babel/core@7.26.10)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
   : dependencies:
@@ -15239,6 +15884,14 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0)
 
+  expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      await-lock: 2.2.2
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    optional: true
+
   expo-sqlite@16.0.10(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       await-lock: 2.2.2
@@ -15330,6 +15983,43 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
+
+  expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3):
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@expo/cli': 54.0.23(expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@18.2.15)(@types/react@18.2.37)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@18.2.0(react@18.2.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-reanimated@4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(typescript@5.8.3)
+      '@expo/config': 12.0.13
+      '@expo/config-plugins': 54.0.4
+      '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      '@expo/fingerprint': 0.15.4
+      '@expo/metro': 54.2.0
+      '@expo/metro-config': 54.0.14(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))
+      '@expo/vector-icons': 15.1.1(expo-font@14.0.11(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      '@ungap/structured-clone': 1.3.0
+      babel-preset-expo: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.26.10)(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-refresh@0.14.2)
+      expo-asset: 12.0.12(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      expo-constants: 18.0.13(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))
+      expo-file-system: 19.0.21(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))
+      expo-font: 14.0.11(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      expo-keep-awake: 15.0.8(expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(react@18.2.0)
+      expo-modules-autolinking: 3.0.24
+      expo-modules-core: 3.0.29(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      pretty-format: 29.7.0
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+      react-refresh: 0.14.2
+      whatwg-url-without-unicode: 8.0.0-3
+    optionalDependencies:
+      '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@18.2.0(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - expo-router
+      - graphql
+      - supports-color
+      - typescript
+      - utf-8-validate
+    optional: true
 
   expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.8.3):
     dependencies:
@@ -17298,6 +17988,11 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
+  react-freeze@1.0.4(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+    optional: true
+
   react-freeze@1.0.4(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -17332,6 +18027,15 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0)
 
+  react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@egjs/hammerjs': 2.0.17
+      hoist-non-react-statics: 3.3.2
+      invariant: 2.2.4
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    optional: true
+
   react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@egjs/hammerjs': 2.0.17
@@ -17345,6 +18049,12 @@ snapshots:
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0)
+
+  react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    optional: true
 
   react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -17360,6 +18070,15 @@ snapshots:
       react-native-worklets: 0.8.1(@babel/core@7.26.10)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       semver: 7.7.4
 
+  react-native-reanimated@4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      react-native-worklets: 0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      semver: 7.7.4
+    optional: true
+
   react-native-reanimated@4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -17374,6 +18093,12 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0)
 
+  react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+    optional: true
+
   react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -17387,6 +18112,15 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.26.10)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.26.10))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       warn-once: 0.1.1
+
+  react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-freeze: 1.0.4(react@18.2.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      warn-once: 0.1.1
+    optional: true
 
   react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -17421,6 +18155,27 @@ snapshots:
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
+
+  react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@react-native/metro-config': 0.85.0(@babel/core@7.29.0)
+      convert-source-map: 2.0.0
+      react: 18.2.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0)
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -17490,6 +18245,54 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0):
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@react-native/assets-registry': 0.81.5
+      '@react-native/codegen': 0.81.5(@babel/core@7.29.0)
+      '@react-native/community-cli-plugin': 0.81.5(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))
+      '@react-native/gradle-plugin': 0.81.5
+      '@react-native/js-polyfills': 0.81.5
+      '@react-native/normalize-colors': 0.81.5
+      '@react-native/virtualized-lists': 0.81.5(@types/react@18.2.37)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@18.2.37)(react@18.2.0))(react@18.2.0)
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      babel-plugin-syntax-hermes-parser: 0.29.1
+      base64-js: 1.5.1
+      commander: 12.1.0
+      flow-enums-runtime: 0.0.6
+      glob: 7.2.3
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      nullthrows: 1.1.1
+      pretty-format: 29.7.0
+      promise: 8.3.0
+      react: 18.2.0
+      react-devtools-core: 6.1.5
+      react-refresh: 0.14.2
+      regenerator-runtime: 0.13.11
+      scheduler: 0.26.0
+      semver: 7.7.4
+      stacktrace-parser: 0.1.10
+      whatwg-fetch: 3.6.20
+      ws: 6.2.3
+      yargs: 17.7.2
+    optionalDependencies:
+      '@types/react': 18.2.37
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-community/cli'
+      - '@react-native/metro-config'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    optional: true
+
   react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.8)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
@@ -17542,6 +18345,15 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@18.2.37)(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-style-singleton: 2.2.3(@types/react@18.2.37)(react@18.2.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
+
   react-remove-scroll-bar@2.3.8(@types/react@19.1.17)(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -17549,6 +18361,18 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.17
+
+  react-remove-scroll@2.7.2(@types/react@18.2.37)(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-remove-scroll-bar: 2.3.8(@types/react@18.2.37)(react@18.2.0)
+      react-style-singleton: 2.2.3(@types/react@18.2.37)(react@18.2.0)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@18.2.37)(react@18.2.0)
+      use-sidecar: 1.1.3(@types/react@18.2.37)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
 
   react-remove-scroll@2.7.2(@types/react@19.1.17)(react@19.1.0):
     dependencies:
@@ -17560,6 +18384,15 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.1.17)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.17
+
+  react-style-singleton@2.2.3(@types/react@18.2.37)(react@18.2.0):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 18.2.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
 
   react-style-singleton@2.2.3(@types/react@19.1.17)(react@19.1.0):
     dependencies:
@@ -18437,6 +19270,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-callback-ref@1.3.3(@types/react@18.2.37)(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
+
   use-callback-ref@1.3.3(@types/react@19.1.17)(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -18448,9 +19289,23 @@ snapshots:
     dependencies:
       react: 18.2.0
 
+  use-latest-callback@0.2.6(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+    optional: true
+
   use-latest-callback@0.2.6(react@19.1.0):
     dependencies:
       react: 19.1.0
+
+  use-sidecar@1.1.3(@types/react@18.2.37)(react@18.2.0):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.2.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.2.37
+    optional: true
 
   use-sidecar@1.1.3(@types/react@19.1.17)(react@19.1.0):
     dependencies:
@@ -18494,6 +19349,16 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+    optional: true
 
   vaul@1.1.2(@types/react-dom@18.2.15)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
## Summary
- Adds "Sign in with Spotify" CTA to unauthenticated Fissa page (Spotify brand compliant)
- Sets up better-auth web client with `createAuthClient`
- Passes Fissa PIN as `callbackURL` so guest returns to the same party after OAuth
- Verifies better-auth callbackURL routing is correctly configured
- Shows Queue interaction controls (Add Track, Vote) only to authenticated guests
- Handles OAuth cancellation/error: shows dismissible banner, no redirect loop

## Test plan
- [x] Unauthenticated visitor sees Sign in CTA (task #58)
- [x] callbackURL includes correct Fissa PIN (tasks #60, #63)
- [x] Authenticated guest sees Add Track and Vote controls (task #66)
- [x] OAuth error shows dismissible banner (task #67)

Closes #46
Closes #58
Closes #60
Closes #63
Closes #66
Closes #67

🤖 Generated with [Claude Code](https://claude.com/code)