### PR TITLE
feat(web): Create a Fissa CTA and stub route

### DIFF
--- a/apps/web/src/components/Hero.tsx
+++ b/apps/web/src/components/Hero.tsx
@@ -1,5 +1,7 @@
 import { useId } from 'react'
+import { useNavigate } from '@tanstack/react-router'
 import { useTheme } from '~/providers/ThemeProvider'
+import { authClient } from '~/lib/auth-client'
 import { AppDemo } from './AppDemo'
 import { AppStoreLink } from './AppStoreLink'
 import { Container } from './Container'
@@ -52,6 +54,19 @@ function BackgroundIllustration(props: React.ComponentPropsWithoutRef<'div'>) {
 
 export function Hero() {
   const { theme } = useTheme()
+  const { data: session } = authClient.useSession()
+  const navigate = useNavigate()
+
+  const handleCreateFissa = () => {
+    if (session?.user) {
+      void navigate({ to: '/fissa/create' })
+    } else {
+      void authClient.signIn.social({
+        provider: 'spotify',
+        callbackURL: '/fissa/create',
+      })
+    }
+  }
 
   return (
     <div className="overflow-hidden py-20 sm:py-32 lg:pb-32 xl:pb-36" style={{ backgroundColor: theme[900] }}>
@@ -65,6 +80,15 @@ export function Hero() {
               Having friends at a party with a bad taste in music stinks. Use Fissa to create a collaborative and democratic playlist for everyone to enjoy.
             </p>
             <div className="mt-8 flex flex-wrap gap-x-6 gap-y-4">
+              <button
+                data-testid="create-fissa-btn"
+                onClick={handleCreateFissa}
+                className="rounded-full px-6 py-3 font-semibold text-white transition-opacity hover:opacity-90 active:opacity-80"
+                style={{ backgroundColor: theme[500] }}
+                type="button"
+              >
+                Create a Fissa
+              </button>
               <AppStoreLink />
               <PlayStoreLink />
             </div>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -10,11 +10,17 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as FissaCreateRouteImport } from './routes/fissa/create'
 import { Route as FissaPinRouteImport } from './routes/fissa/$pin'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FissaCreateRoute = FissaCreateRouteImport.update({
+  id: '/fissa/create',
+  path: '/fissa/create',
   getParentRoute: () => rootRouteImport,
 } as any)
 const FissaPinRoute = FissaPinRouteImport.update({
@@ -25,27 +31,31 @@ const FissaPinRoute = FissaPinRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/fissa/create': typeof FissaCreateRoute
   '/fissa/$pin': typeof FissaPinRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/fissa/create': typeof FissaCreateRoute
   '/fissa/$pin': typeof FissaPinRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/fissa/create': typeof FissaCreateRoute
   '/fissa/$pin': typeof FissaPinRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/fissa/$pin'
+  fullPaths: '/' | '/fissa/create' | '/fissa/$pin'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/fissa/$pin'
-  id: '__root__' | '/' | '/fissa/$pin'
+  to: '/' | '/fissa/create' | '/fissa/$pin'
+  id: '__root__' | '/' | '/fissa/create' | '/fissa/$pin'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  FissaCreateRoute: typeof FissaCreateRoute
   FissaPinRoute: typeof FissaPinRoute
 }
 
@@ -56,6 +66,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/fissa/create': {
+      id: '/fissa/create'
+      path: '/fissa/create'
+      fullPath: '/fissa/create'
+      preLoaderRoute: typeof FissaCreateRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/fissa/$pin': {
@@ -70,6 +87,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  FissaCreateRoute: FissaCreateRoute,
   FissaPinRoute: FissaPinRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/web/src/routes/fissa/create.test.tsx
+++ b/apps/web/src/routes/fissa/create.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * Tests for /fissa/create page and home page CTA (Task #80)
+ *
+ * Scenario: Signed-in user sees and clicks the Create a Fissa CTA
+ *   Given I am signed in as a Party Host
+ *   When I visit the web app home page
+ *   Then I see a "Create a Fissa" button
+ *   When I click it
+ *   Then I am navigated to the Fissa creation page
+ *
+ * Scenario: Unauthenticated user sees sign-in prompt on CTA click
+ *   Given I am not signed in
+ *   When I visit the web app home page
+ *   Then I see a "Create a Fissa" button
+ *   When I click it
+ *   Then I see a sign-in prompt (or I am redirected to sign in)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => () => ({ component: null }),
+  useNavigate: () => mockNavigate,
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string; [key: string]: unknown }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("~/lib/auth-client", () => ({
+  authClient: {
+    useSession: vi.fn().mockReturnValue({ data: null, isPending: false }),
+    signIn: {
+      social: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("~/providers/ThemeProvider", () => ({
+  useTheme: () => ({ theme: { 500: "#ff0", 100: "#fff", 900: "#000" } }),
+}));
+
+vi.mock("~/components/AppDemo", () => ({
+  AppDemo: () => <div data-testid="app-demo" />,
+}));
+
+vi.mock("~/components/AppStoreLink", () => ({
+  AppStoreLink: () => <a href="#app-store">App Store</a>,
+}));
+
+vi.mock("~/components/PlayStoreLink", () => ({
+  PlayStoreLink: () => <a href="#play-store">Play Store</a>,
+}));
+
+vi.mock("~/components/Container", () => ({
+  Container: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("~/components/PhoneFrame", () => ({
+  PhoneFrame: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// ── Imports after mocks ────────────────────────────────────────────────────────
+
+import { authClient } from "~/lib/auth-client";
+import { CreateFissa } from "./create";
+import { Hero } from "~/components/Hero";
+
+// ── Tests — /fissa/create page ──────────────────────────────────────────────────
+
+describe("/fissa/create — Create a Fissa page (Task #80)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockResolvedValue(undefined);
+  });
+
+  /**
+   * Scenario: Page renders the create fissa content
+   */
+  it("renders the create fissa page with data-testid", () => {
+    vi.mocked(authClient.useSession).mockReturnValue({
+      data: { user: { id: "user1", name: "Test User" } },
+      isPending: false,
+    } as any);
+
+    render(<CreateFissa />);
+
+    expect(screen.getByTestId("create-fissa-page")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Authenticated user sees the creation page
+   *   Given I am signed in
+   *   Then I see the Create a Fissa heading
+   */
+  it("shows the Create a Fissa heading", () => {
+    vi.mocked(authClient.useSession).mockReturnValue({
+      data: { user: { id: "user1", name: "Test User" } },
+      isPending: false,
+    } as any);
+
+    render(<CreateFissa />);
+
+    expect(screen.getByText(/create a fissa/i)).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Unauthenticated user sees sign-in prompt on the create page
+   *   Given I am not signed in
+   *   When I visit /fissa/create
+   *   Then I see a sign-in button
+   */
+  it("shows a sign-in button for unauthenticated users", () => {
+    vi.mocked(authClient.useSession).mockReturnValue({
+      data: null,
+      isPending: false,
+    } as any);
+
+    render(<CreateFissa />);
+
+    expect(screen.getByTestId("create-fissa-signin-btn")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Unauthenticated user clicks sign-in — triggers Spotify OAuth
+   */
+  it("triggers Spotify OAuth when unauthenticated user clicks sign-in", () => {
+    vi.mocked(authClient.useSession).mockReturnValue({
+      data: null,
+      isPending: false,
+    } as any);
+
+    render(<CreateFissa />);
+
+    fireEvent.click(screen.getByTestId("create-fissa-signin-btn"));
+
+    expect(authClient.signIn.social).toHaveBeenCalledWith({
+      provider: "spotify",
+      callbackURL: "/fissa/create",
+    });
+  });
+
+  /**
+   * Scenario: Authenticated user does NOT see the sign-in button
+   */
+  it("does not show sign-in button for authenticated users", () => {
+    vi.mocked(authClient.useSession).mockReturnValue({
+      data: { user: { id: "user1", name: "Test User" } },
+      isPending: false,
+    } as any);
+
+    render(<CreateFissa />);
+
+    expect(screen.queryByTestId("create-fissa-signin-btn")).not.toBeInTheDocument();
+  });
+});
+
+// ── Tests — Home page Create a Fissa CTA ──────────────────────────────────────
+
+describe("Home page — Create a Fissa CTA (Task #80)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockResolvedValue(undefined);
+  });
+
+  /**
+   * Scenario: Signed-in user sees the Create a Fissa button on the home page
+   *   Given I am signed in
+   *   When I visit the home page
+   *   Then I see a "Create a Fissa" button
+   */
+  it("renders a Create a Fissa button on the home page", () => {
+    vi.mocked(authClient.useSession).mockReturnValue({
+      data: { user: { id: "user1", name: "Test User" } },
+      isPending: false,
+    } as any);
+
+    render(<Hero />);
+
+    expect(screen.getByTestId("create-fissa-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("create-fissa-btn")).toHaveTextContent(/create a fissa/i);
+  });
+
+  /**
+   * Scenario: Unauthenticated user sees the Create a Fissa button on the home page
+   *   Given I am not signed in
+   *   When I visit the home page
+   *   Then I see a "Create a Fissa" button
+   */
+  it("renders a Create a Fissa button even when unauthenticated", () => {
+    vi.mocked(authClient.useSession).mockReturnValue({
+      data: null,
+      isPending: false,
+    } as any);
+
+    render(<Hero />);
+
+    expect(screen.getByTestId("create-fissa-btn")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Signed-in user clicks the CTA and is navigated to /fissa/create
+   *   Given I am signed in as a Party Host
+   *   When I click "Create a Fissa"
+   *   Then I am navigated to /fissa/create
+   */
+  it("navigates authenticated user to /fissa/create on CTA click", () => {
+    vi.mocked(authClient.useSession).mockReturnValue({
+      data: { user: { id: "user1", name: "Test User" } },
+      isPending: false,
+    } as any);
+
+    render(<Hero />);
+
+    fireEvent.click(screen.getByTestId("create-fissa-btn"));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/fissa/create" });
+  });
+
+  /**
+   * Scenario: Unauthenticated user clicks the CTA — triggers Spotify sign-in
+   *   Given I am not signed in
+   *   When I click "Create a Fissa"
+   *   Then Spotify OAuth is triggered with callbackURL "/fissa/create"
+   */
+  it("triggers Spotify OAuth for unauthenticated user clicking the CTA", () => {
+    vi.mocked(authClient.useSession).mockReturnValue({
+      data: null,
+      isPending: false,
+    } as any);
+
+    render(<Hero />);
+
+    fireEvent.click(screen.getByTestId("create-fissa-btn"));
+
+    expect(authClient.signIn.social).toHaveBeenCalledWith({
+      provider: "spotify",
+      callbackURL: "/fissa/create",
+    });
+  });
+
+  /**
+   * Scenario: Unauthenticated user is NOT auto-redirected — only on click
+   */
+  it("does not trigger sign-in automatically on render for unauthenticated users", () => {
+    vi.mocked(authClient.useSession).mockReturnValue({
+      data: null,
+      isPending: false,
+    } as any);
+
+    render(<Hero />);
+
+    expect(authClient.signIn.social).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/fissa/create.tsx
+++ b/apps/web/src/routes/fissa/create.tsx
@@ -1,0 +1,60 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { type FC } from "react";
+import { authClient } from "~/lib/auth-client";
+
+export const Route = createFileRoute("/fissa/create")({
+  component: CreateFissaRoute,
+});
+
+function CreateFissaRoute() {
+  return <CreateFissa />;
+}
+
+export const CreateFissa: FC = () => {
+  const { data: session } = authClient.useSession();
+  const navigate = useNavigate();
+
+  const handleSignIn = () => {
+    void authClient.signIn.social({
+      provider: "spotify",
+      callbackURL: "/fissa/create",
+    });
+  };
+
+  const handleBack = () => {
+    void navigate({ to: "/" });
+  };
+
+  return (
+    <div data-testid="create-fissa-page" className="flex min-h-screen flex-col items-center justify-center gap-6 px-4 text-center">
+      <h1 className="text-3xl font-bold">Create a Fissa</h1>
+      {session?.user ? (
+        <p className="text-lg text-gray-600">
+          You are signed in as <span className="font-semibold">{session.user.name}</span>. Track
+          search and Fissa creation coming soon!
+        </p>
+      ) : (
+        <div className="flex flex-col items-center gap-4">
+          <p className="text-lg text-gray-600">Sign in with Spotify to create a Fissa.</p>
+          <button
+            data-testid="create-fissa-signin-btn"
+            onClick={handleSignIn}
+            className="flex items-center justify-center gap-3 rounded-full px-6 py-3 font-semibold text-white transition-opacity hover:opacity-90 active:opacity-80"
+            style={{ backgroundColor: "#1DB954" }}
+            type="button"
+          >
+            Sign in with Spotify
+          </button>
+        </div>
+      )}
+      <button
+        data-testid="create-fissa-back-btn"
+        onClick={handleBack}
+        className="text-sm text-gray-500 underline"
+        type="button"
+      >
+        Back to home
+      </button>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

- Adds a "Create a Fissa" CTA button to the home page Hero component
- Authenticated users navigate directly to the new `/fissa/create` stub route
- Unauthenticated users trigger Spotify OAuth with `callbackURL: "/fissa/create"` so they land on the creation page after sign-in
- Updates `routeTree.gen.ts` to include the new route

## Test plan

- [x] 10 new tests covering both Gherkin scenarios (all 86 tests pass)
- [x] `create-fissa-btn` renders on the home page for both auth states
- [x] Authenticated click calls `useNavigate` with `{ to: "/fissa/create" }`
- [x] Unauthenticated click calls `authClient.signIn.social` with correct callbackURL
- [x] `/fissa/create` page renders with `data-testid="create-fissa-page"`
- [x] Unauthenticated `/fissa/create` shows sign-in button that triggers OAuth
- [x] Authenticated `/fissa/create` hides sign-in button

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)