### PR TITLE
feat(web): Add Track sheet entry point

### DIFF
--- a/apps/web/src/components/AddTrackSheet.tsx
+++ b/apps/web/src/components/AddTrackSheet.tsx
@@ -1,0 +1,43 @@
+import { type FC } from "react";
+
+interface AddTrackSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const AddTrackSheet: FC<AddTrackSheetProps> = ({ isOpen, onClose }) => {
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      {/* Sheet */}
+      <div
+        data-testid="add-track-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Add Track"
+        className="fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl bg-background p-6 shadow-lg"
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Add Track</h2>
+          <button
+            data-testid="add-track-sheet-close"
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-2 hover:bg-accent"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+        {/* Search UI — future task */}
+      </div>
+    </>
+  );
+};

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -7,7 +7,7 @@
  * Scenario: Authenticated user does not see Sign in CTA (Task #58)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -81,6 +81,17 @@ vi.mock("~/components/SpotifySignInButton", () => ({
       Sign in with Spotify
     </button>
   ),
+}));
+
+vi.mock("~/components/AddTrackSheet", () => ({
+  AddTrackSheet: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
+    isOpen ? (
+      <div data-testid="add-track-sheet">
+        <button data-testid="add-track-sheet-close" onClick={onClose} type="button">
+          Close
+        </button>
+      </div>
+    ) : null,
 }));
 
 // ── Imports after mocks ────────────────────────────────────────────────────────
@@ -1323,5 +1334,110 @@ describe("/fissa/$pin — App-open CTAs visually secondary (Task #89)", () => {
     const desktopCta = screen.getByTestId("open-desktop-app-cta");
 
     expect(mobileCta.className).toBe(desktopCta.className);
+  });
+});
+
+describe("/fissa/$pin — Add Track sheet entry point (Task #70)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+
+  const activeFissaData = {
+    pin: "1234",
+    currentlyPlayingId: null,
+    tracks: [],
+  };
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: activeFissaData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+  });
+
+  /**
+   * Scenario: Authenticated guest sees the Add Track entry point
+   *   Given I am a signed-in Party Guest on the Fissa page
+   *   When the Fissa page loads
+   *   Then I see an "Add Track" button
+   */
+  it("shows the Add Track button when the visitor is authenticated", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test User" } },
+      isPending: false,
+    } as any);
+
+    render(<QueuePage pin="1234" />);
+
+    expect(screen.getByTestId("add-track-btn")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Guest opens the Add Track sheet
+   *   Given I am a signed-in Party Guest on the Fissa page
+   *   When I click the Add Track button
+   *   Then the Add Track sheet opens
+   */
+  it("opens the Add Track sheet when the Add Track button is clicked", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test User" } },
+      isPending: false,
+    } as any);
+
+    render(<QueuePage pin="1234" />);
+
+    expect(screen.queryByTestId("add-track-sheet")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("add-track-btn"));
+
+    expect(screen.getByTestId("add-track-sheet")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Guest closes the Add Track sheet
+   *   Given the Add Track sheet is open
+   *   When I click the close button
+   *   Then the sheet is dismissed
+   */
+  it("closes the Add Track sheet when the close button is clicked", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test User" } },
+      isPending: false,
+    } as any);
+
+    render(<QueuePage pin="1234" />);
+
+    fireEvent.click(screen.getByTestId("add-track-btn"));
+    expect(screen.getByTestId("add-track-sheet")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("add-track-sheet-close"));
+    expect(screen.queryByTestId("add-track-sheet")).not.toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Add Track sheet is not visible on initial load
+   *   The sheet must be closed by default
+   */
+  it("does not show the Add Track sheet on initial load", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test User" } },
+      isPending: false,
+    } as any);
+
+    render(<QueuePage pin="1234" />);
+
+    expect(screen.queryByTestId("add-track-sheet")).not.toBeInTheDocument();
+  });
+
+  /**
+   * Unauthenticated visitor must not see the Add Track sheet trigger
+   */
+  it("does not show the Add Track button for unauthenticated visitors", () => {
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+
+    render(<QueuePage pin="1234" />);
+
+    expect(screen.queryByTestId("add-track-btn")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { type FC } from "react";
+import { type FC, useState } from "react";
+import { AddTrackSheet } from "~/components/AddTrackSheet";
 import { CurrentlyPlayingTrack } from "~/components/CurrentlyPlayingTrack";
 import { Layout } from "~/components/Layout";
 import { QueueTrackList } from "~/components/QueueTrackList";
@@ -20,6 +21,7 @@ interface QueuePageProps {
 }
 
 export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
   const { data: session, isPending: sessionPending } = authClient.useSession();
   const navigate = useNavigate({ from: "/fissa/$pin" });
   const dismissError = () => void navigate({ to: "/fissa/$pin", params: { pin }, search: {} });
@@ -140,13 +142,19 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
         {/* Queue interaction controls — visible only for authenticated guests */}
         {session?.user && (
           <section data-testid="queue-interaction-controls" className="px-4 py-4">
-            <button data-testid="add-track-btn" className="w-full rounded-full bg-primary px-6 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90" type="button">
+            <button
+              data-testid="add-track-btn"
+              className="w-full rounded-full bg-primary px-6 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+              type="button"
+              onClick={() => setIsSheetOpen(true)}
+            >
               Add Track
             </button>
             <div data-testid="vote-controls">{/* Vote controls — Feature #47 */}</div>
           </section>
         )}
       </div>
+      <AddTrackSheet isOpen={isSheetOpen} onClose={() => setIsSheetOpen(false)} />
     </Layout>
   );
 };


### PR DESCRIPTION
Wires the existing Add Track button on the authenticated Fissa page to open an empty AddTrackSheet modal scaffold.

## Changes
- New `AddTrackSheet` component (empty scaffold, open/close state, `data-testid="add-track-sheet"`)
- `$pin.tsx` now tracks `isSheetOpen` state; button opens sheet via `onClick={() => setIsSheetOpen(true)}`
- 5 new tests covering all 3 Gherkin scenarios (button visible, open on click, close on button click)

Closes #70