### PR TITLE
feat(web): fetch existing votes on Fissa page load

### DIFF
--- a/apps/web/src/components/QueueTrackList.test.tsx
+++ b/apps/web/src/components/QueueTrackList.test.tsx
@@ -196,4 +196,51 @@ describe("QueueTrackList", () => {
     expect(screen.getByTestId("upvote-track-b")).not.toBeDisabled();
     expect(screen.getByTestId("downvote-track-b")).not.toBeDisabled();
   });
+
+  /**
+   * Scenario: Guest's previously cast upvote is shown on load (#69)
+   *   Given I am signed in as a Party Guest and I previously upvoted track "track-123"
+   *   When I load the Fissa page
+   *   Then the upvote button for "track-123" shows as active/selected (aria-pressed=true)
+   */
+  it("marks upvote button as aria-pressed=true when user previously upvoted", () => {
+    const userVotes = new Map<string, 1 | -1>([["track-123", 1]]);
+    render(
+      <QueueTrackList
+        tracks={makeTracks([{ trackId: "track-123", totalScore: 3 }])}
+        isAuthenticated
+        userVotes={userVotes}
+      />,
+    );
+
+    expect(screen.getByTestId("upvote-track-123")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("downvote-track-123")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("marks downvote button as aria-pressed=true when user previously downvoted", () => {
+    const userVotes = new Map<string, 1 | -1>([["track-456", -1]]);
+    render(
+      <QueueTrackList
+        tracks={makeTracks([{ trackId: "track-456", totalScore: -1 }])}
+        isAuthenticated
+        userVotes={userVotes}
+      />,
+    );
+
+    expect(screen.getByTestId("upvote-track-456")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("downvote-track-456")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows both vote buttons as aria-pressed=false when user has not voted on track", () => {
+    render(
+      <QueueTrackList
+        tracks={makeTracks([{ trackId: "track-789", totalScore: 0 }])}
+        isAuthenticated
+        userVotes={new Map()}
+      />,
+    );
+
+    expect(screen.getByTestId("upvote-track-789")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("downvote-track-789")).toHaveAttribute("aria-pressed", "false");
+  });
 });

--- a/apps/web/src/components/QueueTrackList.tsx
+++ b/apps/web/src/components/QueueTrackList.tsx
@@ -11,6 +11,7 @@ interface QueueTrackListProps {
   tracks: QueueTrack[];
   isAuthenticated?: boolean;
   currentlyPlayingId?: string;
+  userVotes?: Map<string, 1 | -1>;
 }
 
 /**
@@ -18,7 +19,7 @@ interface QueueTrackListProps {
  * Each track shows artwork (Spotify CDN), track identifier, and vote tally.
  * Defensively filters out already-played tracks.
  */
-export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticated = false, currentlyPlayingId }) => {
+export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticated = false, currentlyPlayingId, userVotes }) => {
   const sorted = [...tracks]
     .filter((t) => !t.hasBeenPlayed)
     .sort((a, b) => b.totalScore - a.totalScore);
@@ -27,6 +28,7 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticate
     <ul data-testid="track-list" className="flex flex-col gap-3">
       {sorted.map((track) => {
         const artworkUrl = `https://i.scdn.co/image/ab67616d00004851${track.trackId}`;
+        const userVote = userVotes?.get(track.trackId);
 
         return (
           <li
@@ -65,6 +67,7 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticate
                 <button
                   aria-label={`Upvote ${track.trackId}`}
                   data-testid={`upvote-${track.trackId}`}
+                  aria-pressed={userVote === 1}
                   type="button"
                   disabled={track.trackId === currentlyPlayingId}
                 >
@@ -73,6 +76,7 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticate
                 <button
                   aria-label={`Downvote ${track.trackId}`}
                   data-testid={`downvote-${track.trackId}`}
+                  aria-pressed={userVote === -1}
                   type="button"
                   disabled={track.trackId === currentlyPlayingId}
                 >

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -24,6 +24,13 @@ vi.mock("~/utils/api", () => ({
         }),
       },
     },
+    vote: {
+      byFissaFromUser: {
+        useQuery: vi.fn().mockReturnValue({
+          data: undefined,
+        }),
+      },
+    },
   },
 }));
 
@@ -1323,5 +1330,105 @@ describe("/fissa/$pin — App-open CTAs visually secondary (Task #89)", () => {
     const desktopCta = screen.getByTestId("open-desktop-app-cta");
 
     expect(mobileCta.className).toBe(desktopCta.className);
+  });
+});
+
+describe("/fissa/$pin — Fetch existing votes on load (Task #69)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockVoteByFissaFromUser = vi.mocked(api.vote.byFissaFromUser.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+
+  const activeFissaData = {
+    pin: "ABC123",
+    currentlyPlayingId: null,
+    tracks: [
+      { trackId: "track-123", hasBeenPlayed: false, durationMs: 180000, score: 0, totalScore: 3 },
+      { trackId: "track-456", hasBeenPlayed: false, durationMs: 180000, score: 0, totalScore: 1 },
+    ],
+  };
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: activeFissaData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+    mockVoteByFissaFromUser.mockReturnValue({ data: undefined } as any);
+  });
+
+  /**
+   * Scenario: Guest's previously cast upvote is shown on load
+   *   Given I am signed in as a Party Guest
+   *   And I previously upvoted track "track-123"
+   *   When I load the Fissa page
+   *   Then the upvote button for "track-123" shows as active/selected
+   */
+  it("calls vote.byFissaFromUser with { pin } when user is authenticated", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test" } },
+      isPending: false,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(mockVoteByFissaFromUser).toHaveBeenCalledWith(
+      { pin: "ABC123" },
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+
+  it("does not call vote.byFissaFromUser when user is unauthenticated", () => {
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(mockVoteByFissaFromUser).toHaveBeenCalledWith(
+      { pin: "ABC123" },
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it("shows upvote button as aria-pressed=true for a previously upvoted track", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test" } },
+      isPending: false,
+    } as any);
+    mockVoteByFissaFromUser.mockReturnValue({
+      data: [{ trackId: "track-123", score: 1 }],
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("upvote-track-123")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("downvote-track-123")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("shows downvote button as aria-pressed=true for a previously downvoted track", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test" } },
+      isPending: false,
+    } as any);
+    mockVoteByFissaFromUser.mockReturnValue({
+      data: [{ trackId: "track-456", score: -1 }],
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("upvote-track-456")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("downvote-track-456")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows both vote buttons as aria-pressed=false for unvoted tracks", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test" } },
+      isPending: false,
+    } as any);
+    mockVoteByFissaFromUser.mockReturnValue({ data: [] } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("upvote-track-123")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("downvote-track-123")).toHaveAttribute("aria-pressed", "false");
   });
 });

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -23,6 +23,13 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
   const { data: session, isPending: sessionPending } = authClient.useSession();
   const navigate = useNavigate({ from: "/fissa/$pin" });
   const dismissError = () => void navigate({ to: "/fissa/$pin", params: { pin }, search: {} });
+  const { data: votesData } = api.vote.byFissaFromUser.useQuery(
+    { pin },
+    { enabled: !!pin && !!session?.user },
+  );
+  const userVotes = new Map(
+    (votesData ?? []).map((v) => [v.trackId, v.score as 1 | -1]),
+  );
   const { data, isLoading, isError } = api.fissa.byId.useQuery(pin, {
     retry: false,
     enabled: !!pin,
@@ -102,7 +109,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
               No upcoming tracks
             </p>
           ) : (
-            <QueueTrackList tracks={upcomingTracks} isAuthenticated={!!session?.user} currentlyPlayingId={data?.currentlyPlayingId ?? undefined} />
+            <QueueTrackList tracks={upcomingTracks} isAuthenticated={!!session?.user} currentlyPlayingId={data?.currentlyPlayingId ?? undefined} userVotes={session?.user ? userVotes : undefined} />
           )}
         </section>
 


### PR DESCRIPTION
## Summary
- Calls `vote.byFissaFromUser` tRPC query on Fissa page load (enabled only when authenticated)
- Builds a `Map<trackId, score>` from the result and passes it as `userVotes` to `QueueTrackList`
- Renders `aria-pressed` on upvote/downvote buttons to reflect previously cast votes

## Test plan
- [x] 3 new tests in `QueueTrackList.test.tsx` covering `aria-pressed` for upvote, downvote, and unvoted states
- [x] 5 new tests in `$pin.test.tsx` covering query call with correct args (enabled/disabled) and aria-pressed display
- [x] All 80 tests pass (`PASS (80) FAIL (0)`)

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)