### PR TITLE
feat(web): wire vote.create tRPC mutation with optimistic update

### DIFF
--- a/apps/web/src/components/QueueTrackList.test.tsx
+++ b/apps/web/src/components/QueueTrackList.test.tsx
@@ -5,8 +5,8 @@
  * Scenario: Already-played tracks are excluded from the queue
  * Scenario: Currently playing track is excluded from the queue
  */
-import { describe, it, expect } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within, fireEvent } from "@testing-library/react";
 import React from "react";
 import { QueueTrackList } from "./QueueTrackList";
 
@@ -242,5 +242,84 @@ describe("QueueTrackList", () => {
 
     expect(screen.getByTestId("upvote-track-789")).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByTestId("downvote-track-789")).toHaveAttribute("aria-pressed", "false");
+  });
+});
+
+describe("QueueTrackList — onVote callback (Task #71)", () => {
+  /**
+   * Scenario: Guest casts an upvote
+   *   When I click the upvote button on a track
+   *   Then onVote is called with (trackId, 1)
+   */
+  it("calls onVote with (trackId, 1) when upvote button is clicked", () => {
+    const onVote = vi.fn();
+    render(
+      <QueueTrackList
+        isAuthenticated
+        tracks={[{ trackId: "track-a", totalScore: 0, hasBeenPlayed: false, durationMs: 180000 }]}
+        onVote={onVote}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("upvote-track-a"));
+
+    expect(onVote).toHaveBeenCalledWith("track-a", 1);
+    expect(onVote).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * Scenario: Guest casts a downvote
+   *   When I click the downvote button on a track
+   *   Then onVote is called with (trackId, -1)
+   */
+  it("calls onVote with (trackId, -1) when downvote button is clicked", () => {
+    const onVote = vi.fn();
+    render(
+      <QueueTrackList
+        isAuthenticated
+        tracks={[{ trackId: "track-b", totalScore: 0, hasBeenPlayed: false, durationMs: 180000 }]}
+        onVote={onVote}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("downvote-track-b"));
+
+    expect(onVote).toHaveBeenCalledWith("track-b", -1);
+    expect(onVote).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * onVote is not called when button is disabled (currently playing track)
+   */
+  it("does not call onVote when voting on the currently playing track (buttons are disabled)", () => {
+    const onVote = vi.fn();
+    render(
+      <QueueTrackList
+        isAuthenticated
+        currentlyPlayingId="track-c"
+        tracks={[{ trackId: "track-c", totalScore: 0, hasBeenPlayed: false, durationMs: 180000 }]}
+        onVote={onVote}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("upvote-track-c"));
+
+    expect(onVote).not.toHaveBeenCalled();
+  });
+
+  /**
+   * onVote is optional — component renders without it
+   */
+  it("renders without errors when onVote is not provided", () => {
+    render(
+      <QueueTrackList
+        isAuthenticated
+        tracks={[{ trackId: "track-d", totalScore: 0, hasBeenPlayed: false, durationMs: 180000 }]}
+      />,
+    );
+
+    // Should not throw — clicking still works
+    fireEvent.click(screen.getByTestId("upvote-track-d"));
+    expect(screen.getByTestId("upvote-track-d")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/QueueTrackList.tsx
+++ b/apps/web/src/components/QueueTrackList.tsx
@@ -12,6 +12,7 @@ interface QueueTrackListProps {
   isAuthenticated?: boolean;
   currentlyPlayingId?: string;
   userVotes?: Map<string, 1 | -1>;
+  onVote?: (trackId: string, score: 1 | -1) => void;
 }
 
 /**
@@ -19,7 +20,7 @@ interface QueueTrackListProps {
  * Each track shows artwork (Spotify CDN), track identifier, and vote tally.
  * Defensively filters out already-played tracks.
  */
-export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticated = false, currentlyPlayingId, userVotes }) => {
+export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticated = false, currentlyPlayingId, userVotes, onVote }) => {
   const sorted = [...tracks]
     .filter((t) => !t.hasBeenPlayed)
     .sort((a, b) => b.totalScore - a.totalScore);
@@ -70,6 +71,7 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticate
                   aria-pressed={userVote === 1}
                   type="button"
                   disabled={track.trackId === currentlyPlayingId}
+                  onClick={() => onVote?.(track.trackId, 1)}
                 >
                   +1
                 </button>
@@ -79,6 +81,7 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticate
                   aria-pressed={userVote === -1}
                   type="button"
                   disabled={track.trackId === currentlyPlayingId}
+                  onClick={() => onVote?.(track.trackId, -1)}
                 >
                   -1
                 </button>

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -7,7 +7,7 @@
  * Scenario: Authenticated user does not see Sign in CTA (Task #58)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -30,7 +30,20 @@ vi.mock("~/utils/api", () => ({
           data: undefined,
         }),
       },
+      create: {
+        useMutation: vi.fn().mockReturnValue({
+          mutate: vi.fn(),
+        }),
+      },
     },
+    useUtils: vi.fn().mockReturnValue({
+      vote: {
+        byFissaFromUser: { invalidate: vi.fn().mockResolvedValue(undefined) },
+      },
+      fissa: {
+        byId: { invalidate: vi.fn().mockResolvedValue(undefined) },
+      },
+    }),
   },
 }));
 
@@ -1430,5 +1443,197 @@ describe("/fissa/$pin — Fetch existing votes on load (Task #69)", () => {
 
     expect(screen.getByTestId("upvote-track-123")).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByTestId("downvote-track-123")).toHaveAttribute("aria-pressed", "false");
+  });
+});
+
+describe("/fissa/$pin — Wire vote.create mutation (Task #71)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockVoteByFissaFromUser = vi.mocked(api.vote.byFissaFromUser.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+  const mockCreateVoteMutation = vi.mocked(api.vote.create.useMutation);
+
+  const activeFissaData = {
+    pin: "ABC123",
+    currentlyPlayingId: null,
+    tracks: [
+      { trackId: "track-dancing-queen", hasBeenPlayed: false, durationMs: 180000, score: 0, totalScore: 0 },
+      { trackId: "track-barbie-girl", hasBeenPlayed: false, durationMs: 180000, score: 0, totalScore: 0 },
+    ],
+  };
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: activeFissaData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+    mockVoteByFissaFromUser.mockReturnValue({ data: [] } as any);
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test Guest" } },
+      isPending: false,
+    } as any);
+  });
+
+  /**
+   * Scenario: Guest casts an upvote
+   *   Given I am signed in as a Party Guest
+   *   And track "Dancing Queen" is in the Queue
+   *   When I click the upvote button on "Dancing Queen"
+   *   Then the upvote button is shown as active immediately (optimistic)
+   *   And the vote.create mutation is called with score +1
+   */
+  it("calls vote.create mutation with score +1 when upvote button is clicked", () => {
+    const mockMutate = vi.fn();
+    mockCreateVoteMutation.mockReturnValue({ mutate: mockMutate } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    fireEvent.click(screen.getByTestId("upvote-track-dancing-queen"));
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      pin: "ABC123",
+      trackId: "track-dancing-queen",
+      vote: 1,
+    });
+  });
+
+  /**
+   * Scenario: Guest casts a downvote
+   *   Given I am signed in as a Party Guest
+   *   And track "Barbie Girl" is in the Queue
+   *   When I click the downvote button on "Barbie Girl"
+   *   Then the vote.create mutation is called with score -1
+   */
+  it("calls vote.create mutation with score -1 when downvote button is clicked", () => {
+    const mockMutate = vi.fn();
+    mockCreateVoteMutation.mockReturnValue({ mutate: mockMutate } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    fireEvent.click(screen.getByTestId("downvote-track-barbie-girl"));
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      pin: "ABC123",
+      trackId: "track-barbie-girl",
+      vote: -1,
+    });
+  });
+
+  /**
+   * Scenario: Guest casts an upvote — optimistic update shown immediately
+   *   When I click the upvote button
+   *   Then the upvote button shows as active immediately (before server responds)
+   */
+  it("shows upvote button as aria-pressed=true immediately after clicking (optimistic update)", () => {
+    // Simulate onMutate being called immediately by calling it inline
+    mockCreateVoteMutation.mockImplementation(({ onMutate }: any) => ({
+      mutate: (input: any) => {
+        onMutate?.(input);
+      },
+    }));
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("upvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(screen.getByTestId("upvote-track-dancing-queen"));
+
+    expect(screen.getByTestId("upvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("downvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  /**
+   * Scenario: Guest casts a downvote — optimistic update shown immediately
+   */
+  it("shows downvote button as aria-pressed=true immediately after clicking (optimistic update)", () => {
+    mockCreateVoteMutation.mockImplementation(({ onMutate }: any) => ({
+      mutate: (input: any) => {
+        onMutate?.(input);
+      },
+    }));
+
+    render(<QueuePage pin="ABC123" />);
+
+    fireEvent.click(screen.getByTestId("downvote-track-barbie-girl"));
+
+    expect(screen.getByTestId("downvote-track-barbie-girl")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("upvote-track-barbie-girl")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  /**
+   * Scenario: Guest changes vote from upvote to downvote
+   *   Given I previously upvoted "Dancing Queen"
+   *   When I click the downvote button on "Dancing Queen"
+   *   Then the downvote button becomes active and upvote becomes inactive
+   *   And vote.create is called with score -1
+   */
+  it("changes active vote from upvote to downvote when clicking downvote (optimistic)", () => {
+    mockCreateVoteMutation.mockImplementation(({ onMutate }: any) => ({
+      mutate: (input: any) => {
+        onMutate?.(input);
+      },
+    }));
+    // Start with an existing upvote on the track
+    mockVoteByFissaFromUser.mockReturnValue({
+      data: [{ trackId: "track-dancing-queen", score: 1 }],
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    // Initially upvote is active
+    expect(screen.getByTestId("upvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("downvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "false");
+
+    // Click downvote to change the vote
+    fireEvent.click(screen.getByTestId("downvote-track-dancing-queen"));
+
+    // Downvote is now active, upvote is inactive
+    expect(screen.getByTestId("downvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("upvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  /**
+   * Scenario: vote.create is not called for unauthenticated users
+   *   (vote buttons are not rendered for unauthenticated users — verified by prior tests)
+   */
+  it("does not expose onVote when user is not authenticated", () => {
+    const mockMutate = vi.fn();
+    mockCreateVoteMutation.mockReturnValue({ mutate: mockMutate } as any);
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    // No vote buttons should be in the DOM for unauthenticated users
+    expect(screen.queryByTestId("upvote-track-dancing-queen")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("downvote-track-dancing-queen")).not.toBeInTheDocument();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Scenario: On success, cache invalidation is triggered
+   */
+  it("invalidates vote.byFissaFromUser and fissa.byId on mutation success", () => {
+    const mockInvalidateVotes = vi.fn().mockResolvedValue(undefined);
+    const mockInvalidateFissa = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(api.useUtils).mockReturnValue({
+      vote: { byFissaFromUser: { invalidate: mockInvalidateVotes } },
+      fissa: { byId: { invalidate: mockInvalidateFissa } },
+    } as any);
+
+    let capturedOnSuccess: ((data: any) => void) | undefined;
+    mockCreateVoteMutation.mockImplementation(({ onSuccess }: any) => {
+      capturedOnSuccess = onSuccess;
+      return { mutate: vi.fn() };
+    });
+
+    render(<QueuePage pin="ABC123" />);
+
+    // Simulate success callback
+    capturedOnSuccess?.({});
+
+    expect(mockInvalidateVotes).toHaveBeenCalledWith({ pin: "ABC123" });
+    expect(mockInvalidateFissa).toHaveBeenCalledWith("ABC123");
   });
 });

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useCallback, useState } from "react";
 import { type FC } from "react";
 import { CurrentlyPlayingTrack } from "~/components/CurrentlyPlayingTrack";
 import { Layout } from "~/components/Layout";
@@ -23,13 +24,56 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
   const { data: session, isPending: sessionPending } = authClient.useSession();
   const navigate = useNavigate({ from: "/fissa/$pin" });
   const dismissError = () => void navigate({ to: "/fissa/$pin", params: { pin }, search: {} });
+
+  // Optimistic vote state: trackId -> score
+  const [optimisticVotes, setOptimisticVotes] = useState<Map<string, 1 | -1>>(new Map());
+
   const { data: votesData } = api.vote.byFissaFromUser.useQuery(
     { pin },
     { enabled: !!pin && !!session?.user },
   );
+
+  const utils = api.useUtils();
+
+  const { mutate: createVote } = api.vote.create.useMutation({
+    onMutate: ({ trackId, vote }) => {
+      // Optimistic update: immediately reflect new vote state
+      setOptimisticVotes((prev) => {
+        const next = new Map(prev);
+        next.set(trackId, vote as 1 | -1);
+        return next;
+      });
+    },
+    onSuccess: async () => {
+      // Invalidate queries to refresh data from server
+      await utils.vote.byFissaFromUser.invalidate({ pin });
+      await utils.fissa.byId.invalidate(pin);
+    },
+    onError: (_err, { trackId }) => {
+      // Rollback optimistic update on error (full error handling is Task #78)
+      setOptimisticVotes((prev) => {
+        const next = new Map(prev);
+        next.delete(trackId);
+        return next;
+      });
+    },
+  });
+
+  // Merge server votes with optimistic updates (optimistic takes precedence)
   const userVotes = new Map(
     (votesData ?? []).map((v) => [v.trackId, v.score as 1 | -1]),
   );
+  for (const [trackId, score] of optimisticVotes) {
+    userVotes.set(trackId, score);
+  }
+
+  const handleVote = useCallback(
+    (trackId: string, vote: 1 | -1) => {
+      createVote({ pin, trackId, vote });
+    },
+    [createVote, pin],
+  );
+
   const { data, isLoading, isError } = api.fissa.byId.useQuery(pin, {
     retry: false,
     enabled: !!pin,
@@ -109,7 +153,13 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
               No upcoming tracks
             </p>
           ) : (
-            <QueueTrackList tracks={upcomingTracks} isAuthenticated={!!session?.user} currentlyPlayingId={data?.currentlyPlayingId ?? undefined} userVotes={session?.user ? userVotes : undefined} />
+            <QueueTrackList
+              tracks={upcomingTracks}
+              isAuthenticated={!!session?.user}
+              currentlyPlayingId={data?.currentlyPlayingId ?? undefined}
+              userVotes={session?.user ? userVotes : undefined}
+              onVote={session?.user ? handleVote : undefined}
+            />
           )}
         </section>
 


### PR DESCRIPTION
## Summary

- Add `onVote` callback prop to `QueueTrackList` — wires `onClick` handlers on upvote/downvote buttons
- Wire `api.vote.create.useMutation` in `QueuePage` with `onMutate` (optimistic update), `onSuccess` (invalidate `vote.byFissaFromUser` + `fissa.byId`), and `onError` rollback stub
- Optimistic vote state is tracked in local `useState` and merged with server votes (optimistic takes precedence)

## Test plan

- [x] Clicking upvote calls `vote.create` mutation with `{ pin, trackId, vote: 1 }`
- [x] Clicking downvote calls `vote.create` mutation with `{ pin, trackId, vote: -1 }`
- [x] Upvote button shows `aria-pressed=true` immediately after clicking (optimistic)
- [x] Downvote button shows `aria-pressed=true` immediately after clicking (optimistic)
- [x] Changing vote from upvote to downvote: downvote becomes active, upvote becomes inactive
- [x] Unauthenticated users do not see vote buttons (no mutation possible)
- [x] On mutation success: `vote.byFissaFromUser.invalidate` and `fissa.byId.invalidate` called
- [x] `QueueTrackList.onVote` unit tests: upvote/downvote fire `onVote`, disabled buttons do not

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)