### PR TITLE
feat(#72): track search UI with Spotify tRPC endpoint

### DIFF
--- a/apps/web/src/components/AddTrackSheet.test.tsx
+++ b/apps/web/src/components/AddTrackSheet.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for AddTrackSheet component (Task #72)
+ *
+ * Scenario: Sheet is hidden when closed
+ * Scenario: Sheet shows search input when open
+ * Scenario: Loading state shown while searching
+ * Scenario: Search results rendered when tracks returned
+ * Scenario: Close button triggers onClose
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("~/hooks/useDebounce", () => ({
+  useDebounce: (value: unknown) => value,
+}));
+
+const mockUseQuery = vi.fn();
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    spotify: {
+      searchTracks: {
+        useQuery: (...args: unknown[]) => mockUseQuery(...args),
+      },
+    },
+  },
+}));
+
+// ── Imports after mocks ────────────────────────────────────────────────────────
+
+import { AddTrackSheet } from "./AddTrackSheet";
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+const noop = () => void 0;
+
+describe("AddTrackSheet (Task #72)", () => {
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+  });
+
+  /**
+   * Scenario: Sheet is hidden when closed
+   *   Given isOpen=false
+   *   Then the sheet dialog is not in the document
+   */
+  it("renders nothing when isOpen is false", () => {
+    const { container } = render(<AddTrackSheet isOpen={false} onClose={noop} pin="1234" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  /**
+   * Scenario: Sheet shows search input when open
+   *   Given isOpen=true
+   *   Then the search input is visible
+   */
+  it("renders the sheet dialog when isOpen is true", () => {
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" />);
+    expect(screen.getByTestId("add-track-sheet")).toBeInTheDocument();
+  });
+
+  it("renders the search input when open", () => {
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" />);
+    expect(screen.getByTestId("track-search-input")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Close button triggers onClose
+   *   Given isOpen=true
+   *   When the close button is clicked
+   *   Then onClose is called
+   */
+  it("calls onClose when close button is clicked", () => {
+    const onClose = vi.fn();
+    render(<AddTrackSheet isOpen={true} onClose={onClose} pin="1234" />);
+    fireEvent.click(screen.getByTestId("add-track-sheet-close"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    const onClose = vi.fn();
+    render(<AddTrackSheet isOpen={true} onClose={onClose} pin="1234" />);
+    fireEvent.click(screen.getByRole("dialog").previousSibling as Element);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  /**
+   * Scenario: Loading state shown while searching
+   *   Given a non-empty query is pending
+   *   Then the loading indicator is visible
+   */
+  it("shows loading indicator when isLoading is true", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: true });
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" />);
+    expect(screen.getByTestId("track-search-loading")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Search results rendered when tracks returned
+   *   Given searchTracks returns two tracks
+   *   Then each track name, artists, and artwork are displayed
+   */
+  it("renders search results when data is returned", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        tracks: [
+          { id: "t1", name: "Song One", artists: ["Artist A"], albumArt: "https://img/t1.jpg" },
+          { id: "t2", name: "Song Two", artists: ["Artist B", "Artist C"], albumArt: "https://img/t2.jpg" },
+        ],
+      },
+      isLoading: false,
+    });
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" />);
+
+    expect(screen.getByTestId("track-search-results")).toBeInTheDocument();
+    expect(screen.getByTestId("search-result-t1")).toBeInTheDocument();
+    expect(screen.getByTestId("search-result-name-t1")).toHaveTextContent("Song One");
+    expect(screen.getByTestId("search-result-artists-t1")).toHaveTextContent("Artist A");
+    expect(screen.getByTestId("search-result-artwork-t1")).toHaveAttribute("src", "https://img/t1.jpg");
+
+    expect(screen.getByTestId("search-result-t2")).toBeInTheDocument();
+    expect(screen.getByTestId("search-result-artists-t2")).toHaveTextContent("Artist B, Artist C");
+  });
+
+  it("does not render results list when data is empty", () => {
+    mockUseQuery.mockReturnValue({ data: { tracks: [] }, isLoading: false });
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" />);
+    expect(screen.queryByTestId("track-search-results")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/AddTrackSheet.tsx
+++ b/apps/web/src/components/AddTrackSheet.tsx
@@ -1,22 +1,29 @@
-import { type FC } from "react";
+import { type FC, useState } from "react";
+import { api } from "~/utils/api";
+import { useDebounce } from "~/hooks/useDebounce";
 
 interface AddTrackSheetProps {
   isOpen: boolean;
   onClose: () => void;
+  pin: string;
 }
 
-export const AddTrackSheet: FC<AddTrackSheetProps> = ({ isOpen, onClose }) => {
+export const AddTrackSheet: FC<AddTrackSheetProps> = ({ isOpen, onClose, pin }) => {
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebounce(query, 300);
+
+  const { data, isLoading } = api.spotify.searchTracks.useQuery(
+    { query: debouncedQuery },
+    { enabled: debouncedQuery.length > 0 },
+  );
+
+  const results = data?.tracks ?? [];
+
   if (!isOpen) return null;
 
   return (
     <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-40 bg-black/50"
-        onClick={onClose}
-        aria-hidden="true"
-      />
-      {/* Sheet */}
+      <div className="fixed inset-0 z-40 bg-black/50" onClick={onClose} aria-hidden="true" />
       <div
         data-testid="add-track-sheet"
         role="dialog"
@@ -36,7 +43,44 @@ export const AddTrackSheet: FC<AddTrackSheetProps> = ({ isOpen, onClose }) => {
             ✕
           </button>
         </div>
-        {/* Search UI — future task */}
+
+        <input
+          data-testid="track-search-input"
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search Spotify…"
+          className="mt-4 w-full rounded-md border px-4 py-2 text-sm"
+        />
+
+        {isLoading && (
+          <div data-testid="track-search-loading" className="mt-4 text-center text-sm text-gray-500">
+            Searching…
+          </div>
+        )}
+
+        {!isLoading && results.length > 0 && (
+          <ul data-testid="track-search-results" className="mt-4 flex flex-col gap-2">
+            {results.map((track) => (
+              <li key={track.id} data-testid={`search-result-${track.id}`} className="flex items-center gap-3">
+                <img
+                  data-testid={`search-result-artwork-${track.id}`}
+                  src={track.albumArt}
+                  alt={track.name}
+                  className="h-10 w-10 rounded object-cover"
+                />
+                <div>
+                  <p data-testid={`search-result-name-${track.id}`} className="text-sm font-medium">
+                    {track.name}
+                  </p>
+                  <p data-testid={`search-result-artists-${track.id}`} className="text-xs text-gray-500">
+                    {track.artists.join(", ")}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </>
   );

--- a/apps/web/src/hooks/useDebounce.ts
+++ b/apps/web/src/hooks/useDebounce.ts
@@ -1,0 +1,10 @@
+import { useState, useEffect } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+  return debounced;
+}

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -84,7 +84,7 @@ vi.mock("~/components/SpotifySignInButton", () => ({
 }));
 
 vi.mock("~/components/AddTrackSheet", () => ({
-  AddTrackSheet: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
+  AddTrackSheet: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void; pin: string }) =>
     isOpen ? (
       <div data-testid="add-track-sheet">
         <button data-testid="add-track-sheet-close" onClick={onClose} type="button">

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -154,7 +154,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
           </section>
         )}
       </div>
-      <AddTrackSheet isOpen={isSheetOpen} onClose={() => setIsSheetOpen(false)} />
+      <AddTrackSheet isOpen={isSheetOpen} onClose={() => setIsSheetOpen(false)} pin={pin} />
     </Layout>
   );
 };

--- a/packages/api/src/infrastructure/SpotifyService.ts
+++ b/packages/api/src/infrastructure/SpotifyService.ts
@@ -120,4 +120,19 @@ export class SpotifyService implements ISpotifyService {
       }
     }
   };
+
+  searchTracks = async (
+    accessToken: string,
+    query: string,
+  ): Promise<Array<{ id: string; name: string; artists: string[]; albumArt: string }>> => {
+    const { body } = await this.withRetry(() =>
+      this.createClient(accessToken).search(query, ["track"], { limit: 20 }),
+    );
+    return (body.tracks?.items ?? []).map((track) => ({
+      id: track.id,
+      name: track.name,
+      artists: track.artists.map((a) => a.name),
+      albumArt: track.album.images[0]?.url ?? "",
+    }));
+  };
 }

--- a/packages/api/src/interfaces/ISpotifyService.ts
+++ b/packages/api/src/interfaces/ISpotifyService.ts
@@ -30,4 +30,9 @@ export interface ISpotifyService {
   ): Promise<SpotifyApi.TrackObjectSimplified[]>;
 
   pause(accessToken: string): Promise<void>;
+
+  searchTracks(
+    accessToken: string,
+    query: string,
+  ): Promise<Array<{ id: string; name: string; artists: string[]; albumArt: string }>>;
 }

--- a/packages/api/src/interfaces/IUserRepository.ts
+++ b/packages/api/src/interfaces/IUserRepository.ts
@@ -48,6 +48,8 @@ export interface IUserRepository {
 
   findFissaOwnerRefreshData(pin: string): Promise<FissaOwnerRefreshData | undefined>;
 
+  getSpotifyAccessToken(userId: string): Promise<string | null>;
+
   createUserWithAccount(
     spotifyUser: SpotifyApi.CurrentUsersProfileResponse,
     tokens: Awaited<ReturnType<ISpotifyService["codeGrant"]>>,

--- a/packages/api/src/repository/UserRepository.ts
+++ b/packages/api/src/repository/UserRepository.ts
@@ -103,6 +103,14 @@ export class UserRepository implements IUserRepository {
     };
   };
 
+  getSpotifyAccessToken = async (userId: string): Promise<string | null> => {
+    const account = await this.db.query.accounts.findFirst({
+      where: and(eq(accounts.userId, userId), eq(accounts.providerId, "spotify")),
+      columns: { accessToken: true },
+    });
+    return account?.accessToken ?? null;
+  };
+
   createUserWithAccount = async (
     spotifyUser: SpotifyApi.CurrentUsersProfileResponse,
     tokens: Awaited<ReturnType<ISpotifyService["codeGrant"]>>,

--- a/packages/api/src/root.ts
+++ b/packages/api/src/root.ts
@@ -1,5 +1,6 @@
 import { authRouter } from "./router/auth";
 import { fissaRouter } from "./router/fissa";
+import { spotifyRouter } from "./router/spotify";
 import { trackRouter } from "./router/track";
 import { voteRouter } from "./router/vote";
 import { createTRPCRouter } from "./trpc";
@@ -7,6 +8,7 @@ import { createTRPCRouter } from "./trpc";
 export const appRouter = createTRPCRouter({
   auth: authRouter,
   fissa: fissaRouter,
+  spotify: spotifyRouter,
   track: trackRouter,
   vote: voteRouter,
 });

--- a/packages/api/src/router/spotify.ts
+++ b/packages/api/src/router/spotify.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { SpotifyService } from "../infrastructure/SpotifyService";
+import { UserRepository } from "../repository";
+
+export const spotifyRouter = createTRPCRouter({
+  searchTracks: protectedProcedure
+    .input(z.object({ query: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const userRepo = new UserRepository(ctx.database);
+      const accessToken = await userRepo.getSpotifyAccessToken(ctx.session.user.id);
+      if (!accessToken) throw new TRPCError({ code: "UNAUTHORIZED", message: "No Spotify access token" });
+      const spotifyService = new SpotifyService();
+      const tracks = await spotifyService.searchTracks(accessToken, input.query);
+      return { tracks };
+    }),
+});


### PR DESCRIPTION
## Summary
- `spotify.searchTracks` tRPC procedure — fetches Spotify access token from DB, calls Spotify search API
- `AddTrackSheet` search input with debounced query, loading indicator, and results list (name, artists, artwork)
- `useDebounce` hook extracted to `apps/web/src/hooks/`
- 8 new component tests; all 82 tests green

## Test plan
- [ ] Type non-empty query → results appear after 300ms debounce
- [ ] Loading spinner shows while query in-flight
- [ ] Close button and backdrop click both dismiss the sheet
- [ ] Sheet hidden when `isOpen=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)