### PR TITLE
feat(#79): search empty state, add-error with retry, fissa-ended state

### DIFF
--- a/apps/web/src/components/AddTrackSheet.test.tsx
+++ b/apps/web/src/components/AddTrackSheet.test.tsx
@@ -131,3 +131,78 @@ describe("AddTrackSheet (Task #72)", () => {
     expect(screen.queryByTestId("track-search-results")).not.toBeInTheDocument();
   });
 });
+
+describe("AddTrackSheet (Task #79)", () => {
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+  });
+
+  /**
+   * Scenario: Search returns no results
+   *   Given the Add Track sheet is open
+   *   When I type "xyzzy1234567890" and the search completes
+   *   And Spotify returns zero results
+   *   Then I see a "No tracks found" message
+   *   And the search field remains usable
+   */
+  it("shows 'No tracks found' when search returns zero results", () => {
+    mockUseQuery.mockReturnValue({ data: { tracks: [] }, isLoading: false });
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" />);
+
+    const input = screen.getByTestId("track-search-input");
+    fireEvent.change(input, { target: { value: "xyzzy1234567890" } });
+
+    expect(screen.getByTestId("track-search-empty")).toBeInTheDocument();
+    expect(screen.getByTestId("track-search-empty")).toHaveTextContent("No tracks found");
+    expect(input).not.toBeDisabled();
+  });
+
+  /**
+   * Scenario: Network error during track addition
+   *   Given I have selected a track to add
+   *   When the add mutation fails due to a network error
+   *   Then I see an error message indicating the add failed
+   *   And I see a retry button
+   *   And the track is not silently dropped
+   */
+  it("shows error message and retry button when addError is true", () => {
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" addError={true} onRetry={noop} />);
+
+    expect(screen.getByTestId("track-add-error")).toBeInTheDocument();
+    expect(screen.getByTestId("track-add-retry-btn")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Retrying after a network error
+   *   Given an add-error state is shown
+   *   When I tap the retry button
+   *   Then the add mutation is attempted again with the same track
+   */
+  it("calls onRetry when retry button is clicked", () => {
+    const onRetry = vi.fn();
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" addError={true} onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByTestId("track-add-retry-btn"));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  /**
+   * Scenario: Fissa ends while guest is searching
+   *   Given the Add Track sheet is open
+   *   When the Fissa is detected as ended
+   *   Then the sheet shows an ended-Fissa state
+   *   And the search UI is no longer interactive
+   */
+  it("shows fissa-ended state and disables input when fissaEnded is true", () => {
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" fissaEnded={true} />);
+
+    expect(screen.getByTestId("fissa-ended-state")).toBeInTheDocument();
+    expect(screen.getByTestId("track-search-input")).toBeDisabled();
+  });
+
+  it("does not show add-error when fissaEnded is true", () => {
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" fissaEnded={true} addError={true} onRetry={noop} />);
+
+    expect(screen.queryByTestId("track-add-error")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/AddTrackSheet.tsx
+++ b/apps/web/src/components/AddTrackSheet.tsx
@@ -6,9 +6,12 @@ interface AddTrackSheetProps {
   isOpen: boolean;
   onClose: () => void;
   pin: string;
+  addError?: boolean;
+  onRetry?: () => void;
+  fissaEnded?: boolean;
 }
 
-export const AddTrackSheet: FC<AddTrackSheetProps> = ({ isOpen, onClose, pin }) => {
+export const AddTrackSheet: FC<AddTrackSheetProps> = ({ isOpen, onClose, pin, addError, onRetry, fissaEnded }) => {
   const [query, setQuery] = useState("");
   const debouncedQuery = useDebounce(query, 300);
 
@@ -44,6 +47,12 @@ export const AddTrackSheet: FC<AddTrackSheetProps> = ({ isOpen, onClose, pin }) 
           </button>
         </div>
 
+        {fissaEnded ? (
+          <div data-testid="fissa-ended-state" className="mt-4 text-center text-sm text-gray-500">
+            This fissa has ended.
+          </div>
+        ) : null}
+
         <input
           data-testid="track-search-input"
           type="text"
@@ -51,15 +60,16 @@ export const AddTrackSheet: FC<AddTrackSheetProps> = ({ isOpen, onClose, pin }) 
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search Spotify…"
           className="mt-4 w-full rounded-md border px-4 py-2 text-sm"
+          disabled={fissaEnded}
         />
 
-        {isLoading && (
+        {!fissaEnded && isLoading && (
           <div data-testid="track-search-loading" className="mt-4 text-center text-sm text-gray-500">
             Searching…
           </div>
         )}
 
-        {!isLoading && results.length > 0 && (
+        {!fissaEnded && !isLoading && results.length > 0 && (
           <ul data-testid="track-search-results" className="mt-4 flex flex-col gap-2">
             {results.map((track) => (
               <li key={track.id} data-testid={`search-result-${track.id}`} className="flex items-center gap-3">
@@ -80,6 +90,26 @@ export const AddTrackSheet: FC<AddTrackSheetProps> = ({ isOpen, onClose, pin }) 
               </li>
             ))}
           </ul>
+        )}
+
+        {!fissaEnded && !isLoading && results.length === 0 && debouncedQuery.length > 0 && (
+          <div data-testid="track-search-empty" className="mt-4 text-center text-sm text-gray-500">
+            No tracks found
+          </div>
+        )}
+
+        {!fissaEnded && addError && (
+          <div data-testid="track-add-error" className="mt-4 text-center text-sm text-red-500">
+            Failed to add track.{" "}
+            <button
+              data-testid="track-add-retry-btn"
+              type="button"
+              onClick={onRetry}
+              className="underline"
+            >
+              Retry
+            </button>
+          </div>
         )}
       </div>
     </>


### PR DESCRIPTION
## Summary
- Empty state: "No tracks found" when search returns zero results for non-empty query
- Add-error state with retry button for mutation failures
- Fissa-ended state disables search input and suppresses other states
- 5 new tests covering all 4 Gherkin scenarios

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)