### PR TITLE
feat(#83): wire fissa.create tRPC mutation with seed tracks

### DIFF
--- a/apps/web/src/routes/fissa/create.test.tsx
+++ b/apps/web/src/routes/fissa/create.test.tsx
@@ -92,6 +92,11 @@ vi.mock("~/utils/api", () => ({
         useQuery: vi.fn(),
       },
     },
+    fissa: {
+      create: {
+        useMutation: vi.fn(),
+      },
+    },
   },
 }));
 
@@ -111,6 +116,10 @@ describe("/fissa/create — Create a Fissa page (Task #80)", () => {
     vi.mocked(api.spotify.searchTracks.useQuery).mockReturnValue({
       data: undefined,
       isLoading: false,
+    } as any);
+    vi.mocked(api.fissa.create.useMutation).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
     } as any);
   });
 
@@ -262,6 +271,11 @@ describe("CreateFissa — Track search UI (Task #82)", () => {
     vi.mocked(api.spotify.searchTracks.useQuery).mockReturnValue({
       data: undefined,
       isLoading: false,
+    } as any);
+
+    vi.mocked(api.fissa.create.useMutation).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
     } as any);
   });
 
@@ -446,5 +460,102 @@ describe("CreateFissa — Track search UI (Task #82)", () => {
     rerender(<CreateFissa />);
 
     expect(screen.getByTestId("selected-count")).toHaveTextContent("1");
+  });
+});
+
+// ── Tests — fissa.create mutation wiring (Task #83) ──────────────────────────
+
+/**
+ * Scenario: Host submits the creation form successfully
+ *   Given I am on the Fissa creation page
+ *   And I have selected the minimum required number of tracks
+ *   When I click the "Create Fissa" button
+ *   Then the fissa.create mutation is called with my selected track IDs and durationMs
+ *
+ * Scenario: Mutation is in-flight
+ *   Given I have clicked "Create Fissa"
+ *   Then the submit button is disabled
+ *   And a loading spinner is visible
+ *
+ * Scenario: Mutation returns an error
+ *   Given I have clicked "Create Fissa"
+ *   When the server returns an error
+ *   Then the error is surfaced via the error element
+ */
+describe("CreateFissa — fissa.create mutation wiring (Task #83)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockResolvedValue(undefined);
+
+    vi.mocked(authClient.useSession).mockReturnValue({
+      data: { user: { id: "user1", name: "Test User" } },
+      isPending: false,
+    } as any);
+
+    vi.mocked(api.spotify.searchTracks.useQuery).mockReturnValue({
+      data: {
+        tracks: [
+          { id: "track-1", name: "Get Lucky", artists: ["Daft Punk"], albumArt: "https://example.com/art1.jpg", durationMs: 247000 },
+        ],
+      },
+      isLoading: false,
+    } as any);
+
+    vi.mocked(api.fissa.create.useMutation).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as any);
+  });
+
+  it("calls fissa.create mutation with selected tracks when submit is clicked", () => {
+    const mockMutate = vi.fn();
+    vi.mocked(api.fissa.create.useMutation).mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    } as any);
+
+    render(<CreateFissa />);
+
+    fireEvent.click(screen.getByTestId("search-result-track-1"));
+    fireEvent.click(screen.getByTestId("create-fissa-submit-btn"));
+
+    expect(mockMutate).toHaveBeenCalledWith([
+      { trackId: "track-1", durationMs: 247000 },
+    ]);
+  });
+
+  it("disables the submit button and shows loading indicator while mutation is in-flight", () => {
+    vi.mocked(api.fissa.create.useMutation).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+    } as any);
+
+    render(<CreateFissa />);
+
+    fireEvent.click(screen.getByTestId("search-result-track-1"));
+
+    const submitBtn = screen.getByTestId("create-fissa-submit-btn");
+    expect(submitBtn).toBeDisabled();
+    expect(screen.getByTestId("create-fissa-loading")).toBeInTheDocument();
+  });
+
+  it("surfaces mutation error via error element when server returns an error", () => {
+    let capturedOnError: ((err: { message: string }) => void) | undefined;
+
+    vi.mocked(api.fissa.create.useMutation).mockImplementation((opts: any) => {
+      capturedOnError = opts?.onError;
+      return { mutate: vi.fn(), isPending: false } as any;
+    });
+
+    render(<CreateFissa />);
+
+    fireEvent.click(screen.getByTestId("search-result-track-1"));
+    fireEvent.click(screen.getByTestId("create-fissa-submit-btn"));
+
+    act(() => {
+      capturedOnError?.({ message: "Something went wrong" });
+    });
+
+    expect(screen.getByTestId("create-fissa-error")).toHaveTextContent("Something went wrong");
   });
 });

--- a/apps/web/src/routes/fissa/create.tsx
+++ b/apps/web/src/routes/fissa/create.tsx
@@ -18,6 +18,7 @@ type SearchTrack = {
   name: string;
   artists: string[];
   albumArt: string;
+  durationMs: number;
 };
 
 export const CreateFissa: FC = () => {
@@ -26,6 +27,16 @@ export const CreateFissa: FC = () => {
 
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTracks, setSelectedTracks] = useState<Map<string, SearchTrack>>(new Map());
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const { mutate: createFissa, isPending: isCreating } = api.fissa.create.useMutation({
+    onSuccess: (fissa) => {
+      console.log("Fissa created:", fissa.pin);
+    },
+    onError: (err) => {
+      setCreateError(err.message);
+    },
+  });
 
   // Only query when user has typed something
   const { data: searchData, isLoading: isSearchLoading } = api.spotify.searchTracks.useQuery(
@@ -61,6 +72,17 @@ export const CreateFissa: FC = () => {
   const selectedCount = selectedTracks.size;
   const tracksNeeded = Math.max(0, MIN_SEED_TRACKS - selectedCount);
   const canSubmit = selectedCount >= MIN_SEED_TRACKS;
+
+  const handleSubmit = () => {
+    if (!canSubmit || isCreating) return;
+    setCreateError(null);
+    createFissa(
+      Array.from(selectedTracks.values()).map((t) => ({
+        trackId: t.id,
+        durationMs: t.durationMs,
+      })),
+    );
+  };
 
   return (
     <div data-testid="create-fissa-page" className="flex min-h-screen flex-col items-center gap-6 px-4 py-8">
@@ -188,15 +210,21 @@ export const CreateFissa: FC = () => {
             </p>
           )}
 
+          {/* Error message */}
+          {createError && (
+            <p data-testid="create-fissa-error" className="text-sm text-red-600">{createError}</p>
+          )}
+
           {/* Submit button */}
           <button
             data-testid="create-fissa-submit-btn"
-            disabled={!canSubmit}
+            disabled={!canSubmit || isCreating}
             type="button"
+            onClick={handleSubmit}
             className="w-full rounded-full px-6 py-3 font-semibold text-white transition-opacity hover:opacity-90 active:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
             style={{ backgroundColor: "#1DB954" }}
           >
-            Start Fissa
+            {isCreating ? <span data-testid="create-fissa-loading">Creating…</span> : "Start Fissa"}
           </button>
         </div>
       )}

--- a/packages/api/src/infrastructure/SpotifyService.ts
+++ b/packages/api/src/infrastructure/SpotifyService.ts
@@ -124,7 +124,7 @@ export class SpotifyService implements ISpotifyService {
   searchTracks = async (
     accessToken: string,
     query: string,
-  ): Promise<Array<{ id: string; name: string; artists: string[]; albumArt: string }>> => {
+  ): Promise<Array<{ id: string; name: string; artists: string[]; albumArt: string; durationMs: number }>> => {
     const { body } = await this.withRetry(() =>
       this.createClient(accessToken).search(query, ["track"], { limit: 20 }),
     );
@@ -133,6 +133,7 @@ export class SpotifyService implements ISpotifyService {
       name: track.name,
       artists: track.artists.map((a) => a.name),
       albumArt: track.album.images[0]?.url ?? "",
+      durationMs: track.duration_ms,
     }));
   };
 }

--- a/packages/api/src/interfaces/ISpotifyService.ts
+++ b/packages/api/src/interfaces/ISpotifyService.ts
@@ -34,5 +34,5 @@ export interface ISpotifyService {
   searchTracks(
     accessToken: string,
     query: string,
-  ): Promise<Array<{ id: string; name: string; artists: string[]; albumArt: string }>>;
+  ): Promise<Array<{ id: string; name: string; artists: string[]; albumArt: string; durationMs: number }>>;
 }


### PR DESCRIPTION
## Summary
- Add `durationMs` to `SpotifyService.searchTracks` return type and `ISpotifyService` interface
- Wire `api.fissa.create` mutation on form submission with selected track IDs and durations
- Show loading state while mutation is in-flight (button disabled + spinner)
- Surface mutation error via `createError` state and `data-testid="create-fissa-error"` element
- 3 new tests covering all Gherkin scenarios for Task #83

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)