### PR TITLE
feat(fissa): handle premium required and already-hosting creation errors

### DIFF
--- a/apps/web/src/routes/fissa/create.test.tsx
+++ b/apps/web/src/routes/fissa/create.test.tsx
@@ -556,6 +556,242 @@ describe("CreateFissa — fissa.create mutation wiring (Task #83)", () => {
       capturedOnError?.({ message: "Something went wrong" });
     });
 
-    expect(screen.getByTestId("create-fissa-error")).toHaveTextContent("Something went wrong");
+    expect(screen.getByTestId("create-fissa-error")).toBeInTheDocument();
+  });
+});
+
+// ── Tests — Error handling (Task #88) ────────────────────────────────────────
+
+/**
+ * Scenario: Host without Spotify Premium tries to create a Fissa
+ *   Given I am signed in without Spotify Premium
+ *   And I have selected seed tracks
+ *   When I submit the Fissa creation form
+ *   Then I see an error explaining that Spotify Premium is required
+ *   And my selected seed tracks are still shown
+ *
+ * Scenario: Host who already has an active Fissa tries to create another
+ *   Given I already have an active Fissa with PIN "XYZ789"
+ *   And I have selected seed tracks
+ *   When I submit the Fissa creation form
+ *   Then I see an error stating I already have an active Fissa
+ *   And I see a link to navigate to my existing Fissa at /fissa/XYZ789
+ *   And my selected seed tracks are still shown
+ *
+ * Scenario: Network error during creation
+ *   Given I have selected seed tracks
+ *   When I submit the Fissa creation form
+ *   And a network/unknown error occurs
+ *   Then I see a generic error message with a retry affordance
+ *   And my selected seed tracks are still shown
+ */
+describe("CreateFissa — error handling (Task #88)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockResolvedValue(undefined);
+
+    vi.mocked(authClient.useSession).mockReturnValue({
+      data: { user: { id: "user1", name: "Test User" } },
+      isPending: false,
+    } as any);
+
+    vi.mocked(api.spotify.searchTracks.useQuery).mockReturnValue({
+      data: {
+        tracks: [
+          { id: "track-1", name: "Get Lucky", artists: ["Daft Punk"], albumArt: "https://example.com/art1.jpg", durationMs: 247000 },
+        ],
+      },
+      isLoading: false,
+    } as any);
+  });
+
+  it("shows Spotify Premium required error when error code is SPOTIFY_PREMIUM_REQUIRED", () => {
+    let capturedOnError: ((err: { message: string; data?: unknown }) => void) | undefined;
+
+    vi.mocked(api.fissa.create.useMutation).mockImplementation((opts: any) => {
+      capturedOnError = opts?.onError;
+      return { mutate: vi.fn(), isPending: false } as any;
+    });
+
+    render(<CreateFissa />);
+
+    fireEvent.click(screen.getByTestId("search-result-track-1"));
+    fireEvent.click(screen.getByTestId("create-fissa-submit-btn"));
+
+    act(() => {
+      capturedOnError?.({ message: "Spotify Premium required", data: { code: "SPOTIFY_PREMIUM_REQUIRED" } });
+    });
+
+    const errorEl = screen.getByTestId("create-fissa-error");
+    expect(errorEl).toBeInTheDocument();
+    expect(errorEl).toHaveAttribute("data-error-code", "SPOTIFY_PREMIUM_REQUIRED");
+    expect(errorEl).toHaveTextContent(/spotify premium/i);
+  });
+
+  it("preserves selected seed tracks after SPOTIFY_PREMIUM_REQUIRED error", () => {
+    let capturedOnError: ((err: { message: string; data?: unknown }) => void) | undefined;
+
+    vi.mocked(api.fissa.create.useMutation).mockImplementation((opts: any) => {
+      capturedOnError = opts?.onError;
+      return { mutate: vi.fn(), isPending: false } as any;
+    });
+
+    render(<CreateFissa />);
+
+    fireEvent.click(screen.getByTestId("search-result-track-1"));
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1");
+
+    fireEvent.click(screen.getByTestId("create-fissa-submit-btn"));
+
+    act(() => {
+      capturedOnError?.({ message: "Spotify Premium required", data: { code: "SPOTIFY_PREMIUM_REQUIRED" } });
+    });
+
+    // Seed tracks must still be selected
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("selected-tracks-summary")).toBeInTheDocument();
+  });
+
+  it("shows already-hosting error with link to existing Fissa when error code is ALREADY_HOSTING", () => {
+    let capturedOnError: ((err: { message: string; data?: unknown }) => void) | undefined;
+
+    vi.mocked(api.fissa.create.useMutation).mockImplementation((opts: any) => {
+      capturedOnError = opts?.onError;
+      return { mutate: vi.fn(), isPending: false } as any;
+    });
+
+    render(<CreateFissa />);
+
+    fireEvent.click(screen.getByTestId("search-result-track-1"));
+    fireEvent.click(screen.getByTestId("create-fissa-submit-btn"));
+
+    act(() => {
+      capturedOnError?.({ message: "Already hosting a Fissa", data: { code: "ALREADY_HOSTING", existingPin: "XYZ789" } });
+    });
+
+    const errorEl = screen.getByTestId("create-fissa-error");
+    expect(errorEl).toBeInTheDocument();
+    expect(errorEl).toHaveAttribute("data-error-code", "ALREADY_HOSTING");
+    expect(errorEl).toHaveTextContent(/already have an active fissa/i);
+
+    const link = screen.getByTestId("existing-fissa-link");
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/fissa/XYZ789");
+  });
+
+  it("preserves selected seed tracks after ALREADY_HOSTING error", () => {
+    let capturedOnError: ((err: { message: string; data?: unknown }) => void) | undefined;
+
+    vi.mocked(api.fissa.create.useMutation).mockImplementation((opts: any) => {
+      capturedOnError = opts?.onError;
+      return { mutate: vi.fn(), isPending: false } as any;
+    });
+
+    render(<CreateFissa />);
+
+    fireEvent.click(screen.getByTestId("search-result-track-1"));
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1");
+
+    fireEvent.click(screen.getByTestId("create-fissa-submit-btn"));
+
+    act(() => {
+      capturedOnError?.({ message: "Already hosting", data: { code: "ALREADY_HOSTING", existingPin: "XYZ789" } });
+    });
+
+    // Seed tracks must still be selected
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("selected-tracks-summary")).toBeInTheDocument();
+  });
+
+  it("shows generic error with retry button for UNKNOWN errors", () => {
+    let capturedOnError: ((err: { message: string; data?: unknown }) => void) | undefined;
+
+    vi.mocked(api.fissa.create.useMutation).mockImplementation((opts: any) => {
+      capturedOnError = opts?.onError;
+      return { mutate: vi.fn(), isPending: false } as any;
+    });
+
+    render(<CreateFissa />);
+
+    fireEvent.click(screen.getByTestId("search-result-track-1"));
+    fireEvent.click(screen.getByTestId("create-fissa-submit-btn"));
+
+    act(() => {
+      capturedOnError?.({ message: "Internal server error" });
+    });
+
+    const errorEl = screen.getByTestId("create-fissa-error");
+    expect(errorEl).toBeInTheDocument();
+    expect(errorEl).toHaveAttribute("data-error-code", "UNKNOWN");
+    expect(errorEl).toHaveTextContent(/something went wrong/i);
+    expect(screen.getByTestId("create-fissa-retry-btn")).toBeInTheDocument();
+  });
+
+  it("preserves selected seed tracks after UNKNOWN error", () => {
+    let capturedOnError: ((err: { message: string; data?: unknown }) => void) | undefined;
+
+    vi.mocked(api.fissa.create.useMutation).mockImplementation((opts: any) => {
+      capturedOnError = opts?.onError;
+      return { mutate: vi.fn(), isPending: false } as any;
+    });
+
+    render(<CreateFissa />);
+
+    fireEvent.click(screen.getByTestId("search-result-track-1"));
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1");
+
+    fireEvent.click(screen.getByTestId("create-fissa-submit-btn"));
+
+    act(() => {
+      capturedOnError?.({ message: "Network error" });
+    });
+
+    // Seed tracks must still be selected
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("selected-tracks-summary")).toBeInTheDocument();
+  });
+
+  it("detects SPOTIFY_PREMIUM_REQUIRED from error message when data code is absent", () => {
+    let capturedOnError: ((err: { message: string; data?: unknown }) => void) | undefined;
+
+    vi.mocked(api.fissa.create.useMutation).mockImplementation((opts: any) => {
+      capturedOnError = opts?.onError;
+      return { mutate: vi.fn(), isPending: false } as any;
+    });
+
+    render(<CreateFissa />);
+
+    fireEvent.click(screen.getByTestId("search-result-track-1"));
+    fireEvent.click(screen.getByTestId("create-fissa-submit-btn"));
+
+    act(() => {
+      capturedOnError?.({ message: "Spotify Premium subscription required" });
+    });
+
+    const errorEl = screen.getByTestId("create-fissa-error");
+    expect(errorEl).toHaveAttribute("data-error-code", "SPOTIFY_PREMIUM_REQUIRED");
+  });
+
+  it("shows ALREADY_HOSTING without link when existingPin is absent", () => {
+    let capturedOnError: ((err: { message: string; data?: unknown }) => void) | undefined;
+
+    vi.mocked(api.fissa.create.useMutation).mockImplementation((opts: any) => {
+      capturedOnError = opts?.onError;
+      return { mutate: vi.fn(), isPending: false } as any;
+    });
+
+    render(<CreateFissa />);
+
+    fireEvent.click(screen.getByTestId("search-result-track-1"));
+    fireEvent.click(screen.getByTestId("create-fissa-submit-btn"));
+
+    act(() => {
+      capturedOnError?.({ message: "Already hosting a Fissa", data: { code: "ALREADY_HOSTING" } });
+    });
+
+    const errorEl = screen.getByTestId("create-fissa-error");
+    expect(errorEl).toHaveAttribute("data-error-code", "ALREADY_HOSTING");
+    expect(screen.queryByTestId("existing-fissa-link")).not.toBeInTheDocument();
+    expect(errorEl).toHaveTextContent(/end your existing fissa/i);
   });
 });

--- a/apps/web/src/routes/fissa/create.tsx
+++ b/apps/web/src/routes/fissa/create.tsx
@@ -21,20 +21,53 @@ type SearchTrack = {
   durationMs: number;
 };
 
+type CreateErrorCode = "SPOTIFY_PREMIUM_REQUIRED" | "ALREADY_HOSTING" | "UNKNOWN";
+
+type CreateError = {
+  code: CreateErrorCode;
+  existingPin: string | null;
+};
+
+function parseCreateError(err: { message: string; data?: unknown }): CreateError {
+  const errData = err.data as { code?: string; existingPin?: string } | undefined;
+
+  // Check for structured error code in data
+  if (errData?.code === "SPOTIFY_PREMIUM_REQUIRED") {
+    return { code: "SPOTIFY_PREMIUM_REQUIRED", existingPin: null };
+  }
+  if (errData?.code === "ALREADY_HOSTING") {
+    return { code: "ALREADY_HOSTING", existingPin: errData.existingPin ?? null };
+  }
+
+  // Fall back to message-based detection
+  const msg = err.message.toLowerCase();
+  if (msg.includes("premium")) {
+    return { code: "SPOTIFY_PREMIUM_REQUIRED", existingPin: null };
+  }
+  if (msg.includes("already hosting") || msg.includes("already have")) {
+    // Try to extract PIN from message if present (e.g. "XYZ789")
+    const pinMatch = /\b([A-Z0-9]{4,8})\b/.exec(err.message);
+    return { code: "ALREADY_HOSTING", existingPin: pinMatch?.[1] ?? null };
+  }
+
+  return { code: "UNKNOWN", existingPin: null };
+}
+
 export const CreateFissa: FC = () => {
   const { data: session } = authClient.useSession();
   const navigate = useNavigate();
 
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTracks, setSelectedTracks] = useState<Map<string, SearchTrack>>(new Map());
-  const [createError, setCreateError] = useState<string | null>(null);
+  const [createError, setCreateError] = useState<CreateError | null>(null);
 
   const { mutate: createFissa, isPending: isCreating } = api.fissa.create.useMutation({
     onSuccess: (fissa) => {
       console.log("Fissa created:", fissa.pin);
     },
     onError: (err) => {
-      setCreateError(err.message);
+      // Do NOT clear selectedTracks — preserve seed tracks on error
+      setCreateError(parseCreateError(err));
     },
   });
 
@@ -211,8 +244,48 @@ export const CreateFissa: FC = () => {
           )}
 
           {/* Error message */}
-          {createError && (
-            <p data-testid="create-fissa-error" className="text-sm text-red-600">{createError}</p>
+          {createError?.code === "SPOTIFY_PREMIUM_REQUIRED" && (
+            <div data-testid="create-fissa-error" data-error-code="SPOTIFY_PREMIUM_REQUIRED" className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+              <p className="font-semibold">Spotify Premium required</p>
+              <p>Creating a Fissa requires an active Spotify Premium subscription. Please upgrade your account and try again.</p>
+            </div>
+          )}
+
+          {createError?.code === "ALREADY_HOSTING" && (
+            <div data-testid="create-fissa-error" data-error-code="ALREADY_HOSTING" className="rounded-md border border-yellow-200 bg-yellow-50 p-4 text-sm text-yellow-800">
+              <p className="font-semibold">You already have an active Fissa</p>
+              {createError.existingPin ? (
+                <p>
+                  <a
+                    data-testid="existing-fissa-link"
+                    href={`/fissa/${createError.existingPin}`}
+                    className="underline hover:text-yellow-900"
+                  >
+                    Go to your existing Fissa
+                  </a>
+                </p>
+              ) : (
+                <p>Please end your existing Fissa before creating a new one.</p>
+              )}
+            </div>
+          )}
+
+          {createError?.code === "UNKNOWN" && (
+            <div data-testid="create-fissa-error" data-error-code="UNKNOWN" className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+              <p className="font-semibold">Something went wrong</p>
+              <p>
+                An unexpected error occurred. Please{" "}
+                <button
+                  data-testid="create-fissa-retry-btn"
+                  type="button"
+                  onClick={handleSubmit}
+                  className="underline hover:text-red-900"
+                >
+                  try again
+                </button>
+                .
+              </p>
+            </div>
           )}
 
           {/* Submit button */}


### PR DESCRIPTION
## Summary

- Adds `parseCreateError` helper that maps tRPC error data codes (`SPOTIFY_PREMIUM_REQUIRED`, `ALREADY_HOSTING`) or message patterns to a typed `CreateError` state
- Renders distinct error UI: Spotify Premium explanation, "already hosting" warning with link to existing Fissa (`/fissa/<pin>`), and generic UNKNOWN error with retry button
- Seed tracks (`selectedTracks` state) are never cleared on error — preserved across all error cases

## Test plan

- [x] All 102 tests pass (`pnpm test` in `apps/web`)
- [x] No new TypeScript errors in modified files (`tsc --noEmit` shows only pre-existing errors in unrelated files)
- [x] `SPOTIFY_PREMIUM_REQUIRED` error via `data.code` shows premium explanation
- [x] `ALREADY_HOSTING` with `existingPin` renders a direct link to `/fissa/<pin>`
- [x] `ALREADY_HOSTING` without PIN renders fallback text
- [x] `UNKNOWN` / network errors show generic message with retry affordance
- [x] Selected seed tracks remain visible after every error scenario
- [x] Message-based fallback detection for "premium" keyword

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
