### PR TITLE
feat(vote): disable vote controls for currently playing track

### DIFF
--- a/apps/web/src/components/QueueTrackList.test.tsx
+++ b/apps/web/src/components/QueueTrackList.test.tsx
@@ -210,4 +210,135 @@ describe("QueueTrackList", () => {
       expect(screen.queryByTestId("retry-vote-track-b")).not.toBeInTheDocument();
     });
   });
+
+  /**
+   * Task #76: Disable vote controls for currently playing track
+   *
+   * Scenario: Vote controls are disabled on currently playing track
+   *   Given I am signed in as a Party Guest
+   *   And track "Hotel California" is currently playing
+   *   When I view the Queue
+   *   Then the upvote and downvote buttons on "Hotel California" are disabled
+   *   And I cannot click them
+   *
+   * Scenario: Vote controls are enabled on all other queued tracks
+   *   Given I am signed in as a Party Guest
+   *   And track "Hotel California" is currently playing
+   *   And "Roxanne" is queued but not playing
+   *   When I view the Queue
+   *   Then the upvote and downvote buttons on "Roxanne" are enabled
+   */
+  describe("disable vote controls for currently playing track (Task #76)", () => {
+    it("disables upvote button for the currently playing track", () => {
+      render(
+        <QueueTrackList
+          tracks={makeTracks([
+            { trackId: "hotel-california", totalScore: 5 },
+            { trackId: "roxanne", totalScore: 3 },
+          ])}
+          isAuthenticated
+          currentlyPlayingId="hotel-california"
+          onVote={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId("upvote-hotel-california")).toBeDisabled();
+    });
+
+    it("disables downvote button for the currently playing track", () => {
+      render(
+        <QueueTrackList
+          tracks={makeTracks([
+            { trackId: "hotel-california", totalScore: 5 },
+            { trackId: "roxanne", totalScore: 3 },
+          ])}
+          isAuthenticated
+          currentlyPlayingId="hotel-california"
+          onVote={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId("downvote-hotel-california")).toBeDisabled();
+    });
+
+    it("does not disable upvote button for tracks that are not currently playing", () => {
+      render(
+        <QueueTrackList
+          tracks={makeTracks([
+            { trackId: "hotel-california", totalScore: 5 },
+            { trackId: "roxanne", totalScore: 3 },
+          ])}
+          isAuthenticated
+          currentlyPlayingId="hotel-california"
+          onVote={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId("upvote-roxanne")).not.toBeDisabled();
+    });
+
+    it("does not disable downvote button for tracks that are not currently playing", () => {
+      render(
+        <QueueTrackList
+          tracks={makeTracks([
+            { trackId: "hotel-california", totalScore: 5 },
+            { trackId: "roxanne", totalScore: 3 },
+          ])}
+          isAuthenticated
+          currentlyPlayingId="hotel-california"
+          onVote={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId("downvote-roxanne")).not.toBeDisabled();
+    });
+
+    it("does not disable vote buttons when currentlyPlayingId is undefined (nothing playing)", () => {
+      render(
+        <QueueTrackList
+          tracks={makeTracks([{ trackId: "roxanne", totalScore: 3 }])}
+          isAuthenticated
+          currentlyPlayingId={undefined}
+          onVote={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId("upvote-roxanne")).not.toBeDisabled();
+      expect(screen.getByTestId("downvote-roxanne")).not.toBeDisabled();
+    });
+
+    it("disabled vote buttons cannot be clicked (onClick not invoked)", () => {
+      const onVote = vi.fn();
+      render(
+        <QueueTrackList
+          tracks={makeTracks([{ trackId: "hotel-california", totalScore: 5 }])}
+          isAuthenticated
+          currentlyPlayingId="hotel-california"
+          onVote={onVote}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("upvote-hotel-california"));
+      fireEvent.click(screen.getByTestId("downvote-hotel-california"));
+
+      expect(onVote).not.toHaveBeenCalled();
+    });
+
+    it("disabled state applies regardless of prior votes (aria-pressed true but still disabled)", () => {
+      const userVotes = new Map<string, 1 | -1>([["hotel-california", 1]]);
+      render(
+        <QueueTrackList
+          tracks={makeTracks([{ trackId: "hotel-california", totalScore: 5 }])}
+          isAuthenticated
+          currentlyPlayingId="hotel-california"
+          userVotes={userVotes}
+          onVote={vi.fn()}
+        />,
+      );
+
+      const upvote = screen.getByTestId("upvote-hotel-california");
+      expect(upvote).toBeDisabled();
+      expect(upvote).toHaveAttribute("aria-pressed", "true");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add comprehensive TDD tests verifying that vote controls (upvote/downvote buttons) are disabled for the currently playing track in the Queue
- Tests cover both Gherkin scenarios: controls disabled on playing track, controls enabled on other queued tracks
- Feature was already implemented (disabled attribute on vote buttons in QueueTrackList), tests formalise the contract

## Test plan

- [x] Upvote button is disabled for currently playing track
- [x] Downvote button is disabled for currently playing track
- [x] Upvote button is NOT disabled for queued (non-playing) tracks
- [x] Downvote button is NOT disabled for queued (non-playing) tracks
- [x] No crash when `currentlyPlayingId` is undefined (nothing playing) — all controls enabled
- [x] Disabled buttons cannot be clicked (onClick not invoked)
- [x] Disabled state applies regardless of prior votes (aria-pressed preserved)
- [x] All 98 tests pass

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
