### PR TITLE
feat(queue): wire track.addTracks mutation with loading state

### DIFF
--- a/apps/web/src/components/AddTrackSheet.test.tsx
+++ b/apps/web/src/components/AddTrackSheet.test.tsx
@@ -107,8 +107,8 @@ describe("AddTrackSheet (Task #72)", () => {
     mockUseQuery.mockReturnValue({
       data: {
         tracks: [
-          { id: "t1", name: "Song One", artists: ["Artist A"], albumArt: "https://img/t1.jpg" },
-          { id: "t2", name: "Song Two", artists: ["Artist B", "Artist C"], albumArt: "https://img/t2.jpg" },
+          { id: "t1", name: "Song One", durationMs: 180000, artists: ["Artist A"], albumArt: "https://img/t1.jpg" },
+          { id: "t2", name: "Song Two", durationMs: 240000, artists: ["Artist B", "Artist C"], albumArt: "https://img/t2.jpg" },
         ],
       },
       isLoading: false,
@@ -135,8 +135,8 @@ describe("AddTrackSheet (Task #72)", () => {
 // ── Task #74 Tests ─────────────────────────────────────────────────────────────
 
 const tracks = [
-  { id: "t1", name: "Song One", artists: ["Artist A"], albumArt: "https://img/t1.jpg" },
-  { id: "t2", name: "Song Two", artists: ["Artist B", "Artist C"], albumArt: "" },
+  { id: "t1", name: "Song One", durationMs: 180000, artists: ["Artist A"], albumArt: "https://img/t1.jpg" },
+  { id: "t2", name: "Song Two", durationMs: 240000, artists: ["Artist B", "Artist C"], albumArt: "" },
 ];
 
 describe("AddTrackSheet (Task #74)", () => {

--- a/apps/web/src/components/AddTrackSheet.tsx
+++ b/apps/web/src/components/AddTrackSheet.tsx
@@ -5,6 +5,7 @@ import { useDebounce } from "~/hooks/useDebounce";
 export interface SearchTrack {
   id: string;
   name: string;
+  durationMs: number;
   artists: string[];
   albumArt: string;
 }
@@ -14,12 +15,13 @@ interface AddTrackSheetProps {
   onClose: () => void;
   pin: string;
   onSelect?: (track: SearchTrack) => void;
+  isAdding?: boolean;
   addError?: boolean;
   onRetry?: () => void;
   fissaEnded?: boolean;
 }
 
-export const AddTrackSheet: FC<AddTrackSheetProps> = ({ isOpen, onClose, pin, onSelect, addError, onRetry, fissaEnded }) => {
+export const AddTrackSheet: FC<AddTrackSheetProps> = ({ isOpen, onClose, pin, onSelect, isAdding, addError, onRetry, fissaEnded }) => {
   const [query, setQuery] = useState("");
   const debouncedQuery = useDebounce(query, 300);
 
@@ -75,10 +77,16 @@ export const AddTrackSheet: FC<AddTrackSheetProps> = ({ isOpen, onClose, pin, on
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search Spotify…"
           className="mt-4 w-full rounded-md border px-4 py-2 text-sm"
-          disabled={fissaEnded}
+          disabled={fissaEnded ?? isAdding}
         />
 
-        {!fissaEnded && isLoading && (
+        {isAdding && (
+          <div data-testid="add-track-loading" className="mt-4 text-center text-sm text-gray-500">
+            Adding track…
+          </div>
+        )}
+
+        {!fissaEnded && !isAdding && isLoading && (
           <div data-testid="track-search-loading" className="mt-4 text-center text-sm text-gray-500">
             Searching…
           </div>

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -7,7 +7,7 @@
  * Scenario: Authenticated user does not see Sign in CTA (Task #58)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import React from "react";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -21,6 +21,14 @@ vi.mock("~/utils/api", () => ({
           data: undefined,
           isLoading: true,
           error: null,
+        }),
+      },
+    },
+    track: {
+      addTracks: {
+        useMutation: vi.fn().mockReturnValue({
+          mutate: vi.fn(),
+          isPending: false,
         }),
       },
     },
@@ -58,7 +66,7 @@ vi.mock("~/components/Button", () => ({
 }));
 
 vi.mock("~/components/Toast", () => ({
-  toast: { error: vi.fn() },
+  toast: { error: vi.fn(), success: vi.fn() },
 }));
 
 vi.mock("~/components/CurrentlyPlayingTrack", () => ({
@@ -84,11 +92,38 @@ vi.mock("~/components/SpotifySignInButton", () => ({
 }));
 
 vi.mock("~/components/AddTrackSheet", () => ({
-  AddTrackSheet: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void; pin: string }) =>
+  AddTrackSheet: ({
+    isOpen,
+    onClose,
+    onSelect,
+    isAdding,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    pin: string;
+    onSelect?: (track: { id: string; name: string; durationMs: number; artists: string[]; albumArt: string }) => void;
+    isAdding?: boolean;
+  }) =>
     isOpen ? (
       <div data-testid="add-track-sheet">
         <button data-testid="add-track-sheet-close" onClick={onClose} type="button">
           Close
+        </button>
+        {isAdding && <div data-testid="add-track-loading" />}
+        <button
+          data-testid="simulate-select-track"
+          type="button"
+          onClick={() =>
+            onSelect?.({
+              id: "4oLU6hMCjMI75M1A2tKUQ2",
+              name: "Test Song",
+              durationMs: 180000,
+              artists: ["Test Artist"],
+              albumArt: "",
+            })
+          }
+        >
+          Select Track
         </button>
       </div>
     ) : null,
@@ -98,6 +133,7 @@ vi.mock("~/components/AddTrackSheet", () => ({
 
 import { api } from "~/utils/api";
 import { authClient } from "~/lib/auth-client";
+import { toast } from "~/components/Toast";
 import { QueuePage } from "./$pin";
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
@@ -1439,5 +1475,152 @@ describe("/fissa/$pin — Add Track sheet entry point (Task #70)", () => {
     render(<QueuePage pin="1234" />);
 
     expect(screen.queryByTestId("add-track-btn")).not.toBeInTheDocument();
+  });
+});
+
+describe("/fissa/$pin — Wire track.addTracks mutation (Task #75)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+  const mockAddTracksMutation = vi.mocked(api.track.addTracks.useMutation);
+
+  const activeFissaData = {
+    pin: "1234",
+    currentlyPlayingId: null,
+    tracks: [],
+  };
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: activeFissaData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test Guest" } },
+      isPending: false,
+    } as any);
+    mockAddTracksMutation.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as any);
+  });
+
+  /**
+   * Scenario: Successfully adding a track
+   *   When I select a track result
+   *   Then track.addTracks is called with the selected track mapped to { trackId, durationMs }
+   */
+  it("calls track.addTracks mutation when a track is selected from the sheet", () => {
+    const mockMutate = vi.fn();
+    mockAddTracksMutation.mockReturnValue({ mutate: mockMutate, isPending: false } as any);
+
+    render(<QueuePage pin="1234" />);
+
+    // Open the sheet
+    fireEvent.click(screen.getByTestId("add-track-btn"));
+    expect(screen.getByTestId("add-track-sheet")).toBeInTheDocument();
+
+    // Simulate selecting a track via the mock AddTrackSheet
+    fireEvent.click(screen.getByTestId("simulate-select-track"));
+
+    expect(mockMutate).toHaveBeenCalledOnce();
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pin: "1234",
+        tracks: expect.arrayContaining([
+          expect.objectContaining({ trackId: "4oLU6hMCjMI75M1A2tKUQ2", durationMs: 180000 }),
+        ]),
+      }),
+    );
+  });
+
+  /**
+   * Scenario: Loading state while mutation is in-flight
+   *   Given a track addition is in flight
+   *   Then a loading state is shown (isAdding=true passed to sheet)
+   */
+  it("passes isAdding=true to AddTrackSheet while mutation is pending", () => {
+    mockAddTracksMutation.mockReturnValue({ mutate: vi.fn(), isPending: true } as any);
+
+    render(<QueuePage pin="1234" />);
+
+    // Open the sheet
+    fireEvent.click(screen.getByTestId("add-track-btn"));
+
+    expect(screen.getByTestId("add-track-loading")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Preventing double-submission
+   *   Given a track addition is in flight
+   *   When I tap another result
+   *   Then no second mutation is fired
+   */
+  it("does not fire a second mutation while isPending is true", () => {
+    const mockMutate = vi.fn();
+    mockAddTracksMutation.mockReturnValue({ mutate: mockMutate, isPending: true } as any);
+
+    render(<QueuePage pin="1234" />);
+
+    // Open the sheet
+    fireEvent.click(screen.getByTestId("add-track-btn"));
+
+    // Try to select a track while mutation is in-flight
+    fireEvent.click(screen.getByTestId("simulate-select-track"));
+
+    // mutate should NOT have been called
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Scenario: Successfully adding a track — sheet closes
+   *   Given mutation succeeds via onSuccess callback
+   *   Then the sheet is closed
+   */
+  it("closes the sheet on mutation success", () => {
+    let capturedOnSuccess: (() => void) | undefined;
+    mockAddTracksMutation.mockImplementation((callbacks: any) => {
+      capturedOnSuccess = callbacks?.onSuccess;
+      return { mutate: vi.fn(), isPending: false };
+    });
+
+    render(<QueuePage pin="1234" />);
+
+    // Open the sheet
+    fireEvent.click(screen.getByTestId("add-track-btn"));
+    expect(screen.getByTestId("add-track-sheet")).toBeInTheDocument();
+
+    // Simulate success (React state update needs act)
+    act(() => {
+      capturedOnSuccess?.();
+    });
+
+    expect(screen.queryByTestId("add-track-sheet")).not.toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Successfully adding a track — confirmation toast shown
+   *   Given mutation succeeds
+   *   Then a success toast is shown
+   */
+  it("shows a success toast when track is added successfully", () => {
+    let capturedOnSuccess: (() => void) | undefined;
+    mockAddTracksMutation.mockImplementation((callbacks: any) => {
+      capturedOnSuccess = callbacks?.onSuccess;
+      return { mutate: vi.fn(), isPending: false };
+    });
+
+    render(<QueuePage pin="1234" />);
+
+    // Open the sheet
+    fireEvent.click(screen.getByTestId("add-track-btn"));
+
+    // Simulate success
+    act(() => {
+      capturedOnSuccess?.();
+    });
+
+    expect(vi.mocked(toast.success)).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -1,10 +1,11 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { type FC, useState } from "react";
-import { AddTrackSheet } from "~/components/AddTrackSheet";
+import { type FC, useCallback, useState } from "react";
+import { AddTrackSheet, type SearchTrack } from "~/components/AddTrackSheet";
 import { CurrentlyPlayingTrack } from "~/components/CurrentlyPlayingTrack";
 import { Layout } from "~/components/Layout";
 import { QueueTrackList } from "~/components/QueueTrackList";
 import { SpotifySignInButton } from "~/components/SpotifySignInButton";
+import { toast } from "~/components/Toast";
 import { authClient } from "~/lib/auth-client";
 import { api } from "~/utils/api";
 
@@ -31,6 +32,24 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
     refetchInterval: 5000,
     refetchIntervalInBackground: false,
   });
+
+  const { mutate: addTracks, isPending: isAdding } = api.track.addTracks.useMutation({
+    onSuccess: () => {
+      setIsSheetOpen(false);
+      toast.success({ message: "Track added to queue!" });
+    },
+    onError: () => {
+      void navigate({ to: "/fissa/$pin", params: { pin }, search: { error: "add_track_failed" } });
+    },
+  });
+
+  const handleSelect = useCallback(
+    (track: SearchTrack) => {
+      if (isAdding) return;
+      addTracks({ pin, tracks: [{ trackId: track.id, durationMs: track.durationMs }] });
+    },
+    [addTracks, isAdding, pin],
+  );
 
   if (isLoading) {
     return (
@@ -154,7 +173,13 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
           </section>
         )}
       </div>
-      <AddTrackSheet isOpen={isSheetOpen} onClose={() => setIsSheetOpen(false)} pin={pin} />
+      <AddTrackSheet
+        isOpen={isSheetOpen}
+        onClose={() => setIsSheetOpen(false)}
+        pin={pin}
+        onSelect={handleSelect}
+        isAdding={isAdding}
+      />
     </Layout>
   );
 };

--- a/packages/api/src/infrastructure/SpotifyService.ts
+++ b/packages/api/src/infrastructure/SpotifyService.ts
@@ -124,13 +124,14 @@ export class SpotifyService implements ISpotifyService {
   searchTracks = async (
     accessToken: string,
     query: string,
-  ): Promise<Array<{ id: string; name: string; artists: string[]; albumArt: string }>> => {
+  ): Promise<Array<{ id: string; name: string; durationMs: number; artists: string[]; albumArt: string }>> => {
     const { body } = await this.withRetry(() =>
       this.createClient(accessToken).search(query, ["track"], { limit: 20 }),
     );
     return (body.tracks?.items ?? []).map((track) => ({
       id: track.id,
       name: track.name,
+      durationMs: track.duration_ms,
       artists: track.artists.map((a) => a.name),
       albumArt: track.album.images[0]?.url ?? "",
     }));


### PR DESCRIPTION
## Summary

- Wire `api.track.addTracks.useMutation` in `QueuePage` — called when a guest selects a track from the `AddTrackSheet`
- Loading state (`isPending`) passed as `isAdding` to `AddTrackSheet`; double-submission prevented while in-flight
- `onSuccess`: closes sheet and shows success toast; `onError`: navigates to error route
- `durationMs` added to `SearchTrack` interface and `SpotifyService.searchTracks` return type to satisfy the `Z_TRACKS` schema

## Test plan

- [x] `track.addTracks` mutate called with `{ pin, tracks: [{ trackId, durationMs }] }` when track selected
- [x] `isAdding=true` renders loading indicator in sheet while mutation is pending
- [x] No second mutation fired while `isPending=true` (double-submission guard)
- [x] Sheet closes after `onSuccess` callback fires
- [x] Success toast shown after `onSuccess` fires
- All 92 existing + new tests pass

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)
