### PR TITLE
feat(search): implement debounced spotify track search UI

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,7 +1,7 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-04-19T07:52:40.808Z
-> Files: 507 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-04-19T15:11:39.271Z
+> Files: 508 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ./
 
@@ -279,6 +279,7 @@
 - `QueueTrackList.test.tsx` — Tests for QueueTrackList component (Task #61) (~1244 tok)
 - `QueueTrackList.tsx` — Renders the upcoming tracks queue sorted by totalScore descending. (~519 tok)
 - `SecondaryFeatures.tsx` — features — renders chart (~2303 tok)
+- `SpotifySignInButton.test.tsx` — Tests for SpotifySignInButton component (Task #63) (~818 tok)
 - `Toast.tsx` — AUTO_CLOSE_TIME_MS (~298 tok)
 - `TrackList.tsx` — TrackList (~1214 tok)
 
@@ -293,8 +294,8 @@
 
 ## apps/web/src/routes/fissa/
 
-- `$pin.test.tsx` — Tests for /fissa/$pin page (Task #57) (~7261 tok)
-- `$pin.tsx` — Route — uses useQuery, useParams (~949 tok)
+- `$pin.test.tsx` — Tests for /fissa/$pin page (Task #57, #58) (~10976 tok)
+- `$pin.tsx` — Route (~1696 tok)
 
 ## apps/web/src/styles/
 

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -289,6 +289,70 @@
       "related_bugs": [],
       "occurrences": 1,
       "last_seen": "2026-04-18T20:40:49.419Z"
+    },
+    {
+      "id": "bug-019",
+      "timestamp": "2026-04-19T14:57:21.001Z",
+      "error_message": "CSS fix: QueuePage",
+      "file": "apps/web/src/routes/fissa/$pin.tsx",
+      "root_cause": "QueuePage: FC<QueuePageProps> = ({ pin → FC<QueuePageProps> = ({ pin, error",
+      "fix": "Changed QueuePage: FC<QueuePageProps> = ({ pin → FC<QueuePageProps> = ({ pin, error",
+      "tags": [
+        "auto-detected",
+        "style-fix",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-19T14:57:21.001Z"
+    },
+    {
+      "id": "bug-020",
+      "timestamp": "2026-04-19T14:57:35.043Z",
+      "error_message": "Wrong return value",
+      "file": "apps/web/src/routes/fissa/$pin.tsx",
+      "root_cause": "Was returning: <QueuePage pin={pin} />;",
+      "fix": "Now returns: <QueuePage pin={pin} error={error} />;",
+      "tags": [
+        "auto-detected",
+        "return-value",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-19T14:57:35.043Z"
+    },
+    {
+      "id": "bug-021",
+      "timestamp": "2026-04-19T14:58:10.322Z",
+      "error_message": "Type error",
+      "file": "apps/web/src/routes/fissa/$pin.test.tsx",
+      "root_cause": "Missing or incorrect type annotation",
+      "fix": "Added type assertion/annotation",
+      "tags": [
+        "auto-detected",
+        "type-fix",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-19T14:58:10.322Z"
+    },
+    {
+      "id": "bug-022",
+      "timestamp": "2026-04-19T15:11:29.367Z",
+      "error_message": "CSS fix: social",
+      "file": "apps/web/src/components/SpotifySignInButton.test.tsx",
+      "root_cause": "social: mockSignInSocial, → vi.fn(),",
+      "fix": "Changed social: mockSignInSocial, → vi.fn(),",
+      "tags": [
+        "auto-detected",
+        "style-fix",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-19T15:11:29.367Z"
     }
   ],
   "bugs_session_2026_04_10": [

--- a/.wolf/cron-state.json
+++ b/.wolf/cron-state.json
@@ -1,5 +1,5 @@
 {
-  "last_heartbeat": "2026-04-19T09:09:09.967Z",
+  "last_heartbeat": "2026-04-19T15:09:10.123Z",
   "engine_status": "running",
   "execution_log": [
     {

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -1,10 +1,16 @@
 {
-  "session_id": "session-2026-04-19-1136",
-  "started": "2026-04-19T09:36:19.704Z",
-  "files_read": {},
+  "session_id": "session-2026-04-19-1721",
+  "started": "2026-04-19T15:21:44.396Z",
+  "files_read": {
+    "/Users/sander/personal/t3-fissa/.github/workflows/ci.yml": {
+      "count": 1,
+      "tokens": 478,
+      "first_read": "2026-04-19T15:22:15.202Z"
+    }
+  },
   "files_written": [],
   "edit_counts": {},
-  "anatomy_hits": 0,
+  "anatomy_hits": 1,
   "anatomy_misses": 0,
   "repeated_reads_warned": 0,
   "cerebrum_warnings": 0,

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -250,3 +250,17 @@
 
 | Time | Action | File(s) | Outcome | ~Tokens |
 |------|--------|---------|---------|--------|
+| 16:57 | Edited apps/web/src/routes/fissa/$pin.tsx | 12→15 lines | ~191 |
+| 16:57 | Edited apps/web/src/routes/fissa/$pin.tsx | 6→9 lines | ~104 |
+| 16:57 | Edited apps/web/src/routes/fissa/$pin.tsx | expanded (+10 lines) | ~216 |
+| 16:57 | Edited apps/web/src/routes/fissa/$pin.tsx | modified JoinFissa() | ~43 |
+| 16:58 | Edited apps/web/src/routes/fissa/$pin.test.tsx | expanded (+38 lines) | ~501 |
+| 17:00 | Edited apps/web/src/routes/fissa/$pin.tsx | 25→20 lines | ~331 |
+| 17:11 | Edited apps/web/src/components/SpotifySignInButton.test.tsx | 8→6 lines | ~50 |
+| 17:11 | Edited apps/web/src/components/SpotifySignInButton.test.tsx | 6→9 lines | ~101 |
+| 17:14 | Session end: 8 writes across 3 files ($pin.tsx, $pin.test.tsx, SpotifySignInButton.test.tsx) | 3 reads | ~14728 tok |
+
+## Session: 2026-04-19 17:21
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -2,14 +2,14 @@
   "version": 1,
   "created_at": "2026-04-10T17:27:26.117Z",
   "lifetime": {
-    "total_tokens_estimated": 411889,
-    "total_reads": 224,
-    "total_writes": 273,
-    "total_sessions": 27,
-    "anatomy_hits": 221,
-    "anatomy_misses": 3,
-    "repeated_reads_blocked": 32,
-    "estimated_savings_vs_bare_cli": 110704
+    "total_tokens_estimated": 426617,
+    "total_reads": 227,
+    "total_writes": 281,
+    "total_sessions": 28,
+    "anatomy_hits": 223,
+    "anatomy_misses": 4,
+    "repeated_reads_blocked": 41,
+    "estimated_savings_vs_bare_cli": 190151
   },
   "sessions": [
     {
@@ -3260,6 +3260,81 @@
         "writes_count": 1,
         "repeated_reads_blocked": 0,
         "anatomy_lookups": 1
+      }
+    },
+    {
+      "id": "session-2026-04-19-1136",
+      "started": "2026-04-19T09:36:19.704Z",
+      "ended": "2026-04-19T15:14:49.733Z",
+      "reads": [
+        {
+          "file": "/Users/sander/personal/t3-fissa/apps/web/src/routes/fissa/$pin.tsx",
+          "tokens_estimated": 1429,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/t3-fissa/apps/web/src/routes/fissa/$pin.test.tsx",
+          "tokens_estimated": 10976,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/t3-fissa/apps/web/src/components/SpotifySignInButton.test.tsx",
+          "tokens_estimated": 786,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/Users/sander/personal/t3-fissa/apps/web/src/routes/fissa/$pin.tsx",
+          "tokens_estimated": 191,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/t3-fissa/apps/web/src/routes/fissa/$pin.tsx",
+          "tokens_estimated": 104,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/t3-fissa/apps/web/src/routes/fissa/$pin.tsx",
+          "tokens_estimated": 216,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/t3-fissa/apps/web/src/routes/fissa/$pin.tsx",
+          "tokens_estimated": 43,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/t3-fissa/apps/web/src/routes/fissa/$pin.test.tsx",
+          "tokens_estimated": 501,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/t3-fissa/apps/web/src/routes/fissa/$pin.tsx",
+          "tokens_estimated": 331,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/t3-fissa/apps/web/src/components/SpotifySignInButton.test.tsx",
+          "tokens_estimated": 50,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/t3-fissa/apps/web/src/components/SpotifySignInButton.test.tsx",
+          "tokens_estimated": 101,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 13191,
+        "output_tokens_estimated": 1537,
+        "reads_count": 3,
+        "writes_count": 8,
+        "repeated_reads_blocked": 9,
+        "anatomy_lookups": 2
       }
     }
   ],

--- a/apps/web/src/components/AddTrackSheet.test.tsx
+++ b/apps/web/src/components/AddTrackSheet.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Tests for AddTrackSheet component (Task #72)
+ *
+ * Scenario: Sheet is hidden when closed
+ * Scenario: Sheet shows search input when open
+ * Scenario: Loading state shown while searching
+ * Scenario: Search results rendered when tracks returned
+ * Scenario: Close button triggers onClose
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockUseTrackSearch = vi.fn();
+
+vi.mock("~/hooks/useTrackSearch", () => ({
+  useTrackSearch: () => mockUseTrackSearch(),
+}));
+
+// ── Imports after mocks ────────────────────────────────────────────────────────
+
+import { AddTrackSheet } from "./AddTrackSheet";
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+const noop = () => void 0;
+
+describe("AddTrackSheet (Task #72)", () => {
+  beforeEach(() => {
+    mockUseTrackSearch.mockReturnValue({ results: [], isLoading: false, query: "", setQuery: vi.fn() });
+  });
+
+  /**
+   * Scenario: Sheet is hidden when closed
+   *   Given isOpen=false
+   *   Then the sheet dialog is not in the document
+   */
+  it("renders nothing when isOpen is false", () => {
+    const { container } = render(<AddTrackSheet isOpen={false} onClose={noop} pin="1234" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  /**
+   * Scenario: Sheet shows search input when open
+   *   Given isOpen=true
+   *   Then the search input is visible
+   */
+  it("renders the sheet dialog when isOpen is true", () => {
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" />);
+    expect(screen.getByTestId("add-track-sheet")).toBeInTheDocument();
+  });
+
+  it("renders the search input when open", () => {
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" />);
+    expect(screen.getByTestId("track-search-input")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Close button triggers onClose
+   *   Given isOpen=true
+   *   When the close button is clicked
+   *   Then onClose is called
+   */
+  it("calls onClose when close button is clicked", () => {
+    const onClose = vi.fn();
+    render(<AddTrackSheet isOpen={true} onClose={onClose} pin="1234" />);
+    fireEvent.click(screen.getByTestId("add-track-sheet-close"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    const onClose = vi.fn();
+    render(<AddTrackSheet isOpen={true} onClose={onClose} pin="1234" />);
+    fireEvent.click(screen.getByRole("dialog").previousSibling as Element);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  /**
+   * Scenario: Loading state shown while searching
+   *   Given a non-empty query is pending
+   *   Then the loading indicator is visible
+   */
+  it("shows loading indicator when isLoading is true", () => {
+    mockUseTrackSearch.mockReturnValue({ results: [], isLoading: true, query: "Bohemian", setQuery: vi.fn() });
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" />);
+    expect(screen.getByTestId("track-search-loading")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Search results rendered when tracks returned
+   *   Given searchTracks returns two tracks
+   *   Then each track name, artists, and artwork are displayed
+   */
+  it("renders search results when data is returned", () => {
+    mockUseTrackSearch.mockReturnValue({
+      results: [
+        { id: "t1", name: "Song One", artists: ["Artist A"], albumArt: "https://img/t1.jpg" },
+        { id: "t2", name: "Song Two", artists: ["Artist B", "Artist C"], albumArt: "https://img/t2.jpg" },
+      ],
+      isLoading: false,
+      query: "Song",
+      setQuery: vi.fn(),
+    });
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" />);
+
+    expect(screen.getByTestId("track-search-results")).toBeInTheDocument();
+    expect(screen.getByTestId("search-result-t1")).toBeInTheDocument();
+    expect(screen.getByTestId("search-result-name-t1")).toHaveTextContent("Song One");
+    expect(screen.getByTestId("search-result-artists-t1")).toHaveTextContent("Artist A");
+    expect(screen.getByTestId("search-result-artwork-t1")).toHaveAttribute("src", "https://img/t1.jpg");
+
+    expect(screen.getByTestId("search-result-t2")).toBeInTheDocument();
+    expect(screen.getByTestId("search-result-artists-t2")).toHaveTextContent("Artist B, Artist C");
+  });
+
+  it("does not render results list when data is empty", () => {
+    mockUseTrackSearch.mockReturnValue({ results: [], isLoading: false, query: "", setQuery: vi.fn() });
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" />);
+    expect(screen.queryByTestId("track-search-results")).not.toBeInTheDocument();
+  });
+});
+
+// ── Task #74 Tests ─────────────────────────────────────────────────────────────
+
+const tracks = [
+  { id: "t1", name: "Song One", artists: ["Artist A"], albumArt: "https://img/t1.jpg" },
+  { id: "t2", name: "Song Two", artists: ["Artist B", "Artist C"], albumArt: "" },
+];
+
+describe("AddTrackSheet (Task #74)", () => {
+  beforeEach(() => {
+    mockUseTrackSearch.mockReturnValue({
+      results: tracks,
+      isLoading: false,
+      query: "Song",
+      setQuery: vi.fn(),
+    });
+  });
+
+  /**
+   * Scenario: Search result shows artwork, title, and artist
+   *   Given search results are loaded
+   *   Then each result item shows an album artwork thumbnail
+   *   And each result item shows the track title
+   *   And each result item shows the artist name
+   */
+  it("shows artwork, title, and artist for each result", () => {
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" />);
+
+    expect(screen.getByTestId("search-result-artwork-t1")).toBeInTheDocument();
+    expect(screen.getByTestId("search-result-name-t1")).toHaveTextContent("Song One");
+    expect(screen.getByTestId("search-result-artists-t1")).toHaveTextContent("Artist A");
+
+    expect(screen.getByTestId("search-result-name-t2")).toHaveTextContent("Song Two");
+    expect(screen.getByTestId("search-result-artists-t2")).toHaveTextContent("Artist B, Artist C");
+  });
+
+  /**
+   * Scenario: Artwork fallback when no image is available
+   *   Given a search result has no artwork URL
+   *   Then a placeholder image is shown instead
+   */
+  it("shows a placeholder when albumArt is empty", () => {
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" />);
+
+    // t1 has artwork — img element expected
+    const t1Artwork = screen.getByTestId("search-result-artwork-t1");
+    expect(t1Artwork.tagName).toBe("IMG");
+
+    // t2 has no artwork — placeholder div expected (no img src)
+    const t2Artwork = screen.getByTestId("search-result-artwork-t2");
+    expect(t2Artwork.tagName).not.toBe("IMG");
+    expect(t2Artwork).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Selecting a result via click
+   *   Given search results are displayed
+   *   When I click a track result item
+   *   Then the onSelect callback is called with that track
+   */
+  it("calls onSelect with the track when a result is clicked", () => {
+    const onSelect = vi.fn();
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByTestId("search-result-t1"));
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith(tracks[0]);
+  });
+
+  /**
+   * Scenario: Selecting a result via keyboard
+   *   Given search results are displayed and focused
+   *   When I press Enter on a track result item
+   *   Then the onSelect callback is called with that track
+   */
+  it("calls onSelect with the track when Enter is pressed on a result", () => {
+    const onSelect = vi.fn();
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" onSelect={onSelect} />);
+
+    fireEvent.keyDown(screen.getByTestId("search-result-t1"), { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith(tracks[0]);
+  });
+
+  it("calls onSelect with the track when Space is pressed on a result", () => {
+    const onSelect = vi.fn();
+    render(<AddTrackSheet isOpen={true} onClose={noop} pin="1234" onSelect={onSelect} />);
+
+    fireEvent.keyDown(screen.getByTestId("search-result-t1"), { key: " " });
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith(tracks[0]);
+  });
+});

--- a/apps/web/src/components/AddTrackSheet.tsx
+++ b/apps/web/src/components/AddTrackSheet.tsx
@@ -1,0 +1,142 @@
+import { type FC, type KeyboardEvent } from "react";
+import { useTrackSearch } from "~/hooks/useTrackSearch";
+
+export interface SearchTrack {
+  id: string;
+  name: string;
+  artists: string[];
+  albumArt: string;
+}
+
+interface AddTrackSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  pin: string;
+  onSelect?: (track: SearchTrack) => void;
+  addError?: boolean;
+  onRetry?: () => void;
+  fissaEnded?: boolean;
+}
+
+export const AddTrackSheet: FC<AddTrackSheetProps> = ({ isOpen, onClose, pin, onSelect, addError, onRetry, fissaEnded }) => {
+  const { query, setQuery, results, isLoading } = useTrackSearch();
+  const debouncedQuery = query.trim();
+
+  if (!isOpen) return null;
+
+  const handleTrackKeyDown = (e: KeyboardEvent<HTMLLIElement>, track: SearchTrack) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onSelect?.(track);
+    }
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 bg-black/50" onClick={onClose} aria-hidden="true" />
+      <div
+        data-testid="add-track-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Add Track"
+        className="fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl bg-background p-6 shadow-lg"
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Add Track</h2>
+          <button
+            data-testid="add-track-sheet-close"
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-2 hover:bg-accent"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        {fissaEnded ? (
+          <div data-testid="fissa-ended-state" className="mt-4 text-center text-sm text-gray-500">
+            This fissa has ended.
+          </div>
+        ) : null}
+
+        <input
+          data-testid="track-search-input"
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search Spotify…"
+          className="mt-4 w-full rounded-md border px-4 py-2 text-sm"
+          disabled={fissaEnded}
+        />
+
+        {!fissaEnded && isLoading && (
+          <div data-testid="track-search-loading" className="mt-4 text-center text-sm text-gray-500">
+            Searching…
+          </div>
+        )}
+
+        {!fissaEnded && !isLoading && results.length > 0 && (
+          <ul data-testid="track-search-results" className="mt-4 flex flex-col gap-2">
+            {results.map((track) => (
+              <li
+                key={track.id}
+                data-testid={`search-result-${track.id}`}
+                className="flex cursor-pointer items-center gap-3 rounded-md p-1 hover:bg-accent"
+                role="button"
+                tabIndex={0}
+                onClick={() => onSelect?.(track)}
+                onKeyDown={(e) => handleTrackKeyDown(e, track)}
+              >
+                {track.albumArt ? (
+                  <img
+                    data-testid={`search-result-artwork-${track.id}`}
+                    src={track.albumArt}
+                    alt={track.name}
+                    className="h-10 w-10 rounded object-cover"
+                  />
+                ) : (
+                  <div
+                    data-testid={`search-result-artwork-${track.id}`}
+                    className="flex h-10 w-10 items-center justify-center rounded bg-gray-200 text-gray-400"
+                    aria-label="No artwork"
+                  >
+                    ?
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  <p data-testid={`search-result-name-${track.id}`} className="truncate text-sm font-medium">
+                    {track.name}
+                  </p>
+                  <p data-testid={`search-result-artists-${track.id}`} className="truncate text-xs text-gray-500">
+                    {track.artists.join(", ")}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {!fissaEnded && !isLoading && results.length === 0 && debouncedQuery.length > 0 && (
+          <div data-testid="track-search-empty" className="mt-4 text-center text-sm text-gray-500">
+            No tracks found
+          </div>
+        )}
+
+        {!fissaEnded && addError && (
+          <div data-testid="track-add-error" className="mt-4 text-center text-sm text-red-500">
+            Failed to add track.{" "}
+            <button
+              data-testid="track-add-retry-btn"
+              type="button"
+              onClick={onRetry}
+              className="underline"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};

--- a/apps/web/src/components/QueueTrackList.test.tsx
+++ b/apps/web/src/components/QueueTrackList.test.tsx
@@ -210,4 +210,135 @@ describe("QueueTrackList", () => {
       expect(screen.queryByTestId("retry-vote-track-b")).not.toBeInTheDocument();
     });
   });
+
+  /**
+   * Task #76: Disable vote controls for currently playing track
+   *
+   * Scenario: Vote controls are disabled on currently playing track
+   *   Given I am signed in as a Party Guest
+   *   And track "Hotel California" is currently playing
+   *   When I view the Queue
+   *   Then the upvote and downvote buttons on "Hotel California" are disabled
+   *   And I cannot click them
+   *
+   * Scenario: Vote controls are enabled on all other queued tracks
+   *   Given I am signed in as a Party Guest
+   *   And track "Hotel California" is currently playing
+   *   And "Roxanne" is queued but not playing
+   *   When I view the Queue
+   *   Then the upvote and downvote buttons on "Roxanne" are enabled
+   */
+  describe("disable vote controls for currently playing track (Task #76)", () => {
+    it("disables upvote button for the currently playing track", () => {
+      render(
+        <QueueTrackList
+          tracks={makeTracks([
+            { trackId: "hotel-california", totalScore: 5 },
+            { trackId: "roxanne", totalScore: 3 },
+          ])}
+          isAuthenticated
+          currentlyPlayingId="hotel-california"
+          onVote={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId("upvote-hotel-california")).toBeDisabled();
+    });
+
+    it("disables downvote button for the currently playing track", () => {
+      render(
+        <QueueTrackList
+          tracks={makeTracks([
+            { trackId: "hotel-california", totalScore: 5 },
+            { trackId: "roxanne", totalScore: 3 },
+          ])}
+          isAuthenticated
+          currentlyPlayingId="hotel-california"
+          onVote={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId("downvote-hotel-california")).toBeDisabled();
+    });
+
+    it("does not disable upvote button for tracks that are not currently playing", () => {
+      render(
+        <QueueTrackList
+          tracks={makeTracks([
+            { trackId: "hotel-california", totalScore: 5 },
+            { trackId: "roxanne", totalScore: 3 },
+          ])}
+          isAuthenticated
+          currentlyPlayingId="hotel-california"
+          onVote={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId("upvote-roxanne")).not.toBeDisabled();
+    });
+
+    it("does not disable downvote button for tracks that are not currently playing", () => {
+      render(
+        <QueueTrackList
+          tracks={makeTracks([
+            { trackId: "hotel-california", totalScore: 5 },
+            { trackId: "roxanne", totalScore: 3 },
+          ])}
+          isAuthenticated
+          currentlyPlayingId="hotel-california"
+          onVote={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId("downvote-roxanne")).not.toBeDisabled();
+    });
+
+    it("does not disable vote buttons when currentlyPlayingId is undefined (nothing playing)", () => {
+      render(
+        <QueueTrackList
+          tracks={makeTracks([{ trackId: "roxanne", totalScore: 3 }])}
+          isAuthenticated
+          currentlyPlayingId={undefined}
+          onVote={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId("upvote-roxanne")).not.toBeDisabled();
+      expect(screen.getByTestId("downvote-roxanne")).not.toBeDisabled();
+    });
+
+    it("disabled vote buttons cannot be clicked (onClick not invoked)", () => {
+      const onVote = vi.fn();
+      render(
+        <QueueTrackList
+          tracks={makeTracks([{ trackId: "hotel-california", totalScore: 5 }])}
+          isAuthenticated
+          currentlyPlayingId="hotel-california"
+          onVote={onVote}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("upvote-hotel-california"));
+      fireEvent.click(screen.getByTestId("downvote-hotel-california"));
+
+      expect(onVote).not.toHaveBeenCalled();
+    });
+
+    it("disabled state applies regardless of prior votes (aria-pressed true but still disabled)", () => {
+      const userVotes = new Map<string, 1 | -1>([["hotel-california", 1]]);
+      render(
+        <QueueTrackList
+          tracks={makeTracks([{ trackId: "hotel-california", totalScore: 5 }])}
+          isAuthenticated
+          currentlyPlayingId="hotel-california"
+          userVotes={userVotes}
+          onVote={vi.fn()}
+        />,
+      );
+
+      const upvote = screen.getByTestId("upvote-hotel-california");
+      expect(upvote).toBeDisabled();
+      expect(upvote).toHaveAttribute("aria-pressed", "true");
+    });
+  });
 });

--- a/apps/web/src/components/QueueTrackList.test.tsx
+++ b/apps/web/src/components/QueueTrackList.test.tsx
@@ -245,6 +245,137 @@ describe("QueueTrackList", () => {
   });
 });
 
+describe("QueueTrackList — queue re-order after vote (Task #73)", () => {
+  /**
+   * Scenario: Queue re-orders after upvote
+   *   Given the Queue has tracks A (score 2), B (score 0), C (score -1)
+   *   When a Guest upvotes track B (score becomes 1)
+   *   Then the Queue order is A (score 2), B (score 1), C (score -1)
+   */
+  it("re-renders in new score order when track scores change after a vote", () => {
+    const { rerender } = render(
+      <QueueTrackList
+        tracks={makeTracks([
+          { trackId: "track-A", totalScore: 2 },
+          { trackId: "track-B", totalScore: 0 },
+          { trackId: "track-C", totalScore: -1 },
+        ])}
+      />,
+    );
+
+    // Initial order: A, B, C
+    let items = screen.getAllByTestId("track-item");
+    expect(items[0]).toHaveAttribute("data-trackid", "track-A");
+    expect(items[1]).toHaveAttribute("data-trackid", "track-B");
+    expect(items[2]).toHaveAttribute("data-trackid", "track-C");
+
+    // Simulate vote success — track-B score rises to 1
+    rerender(
+      <QueueTrackList
+        tracks={makeTracks([
+          { trackId: "track-A", totalScore: 2 },
+          { trackId: "track-B", totalScore: 1 },
+          { trackId: "track-C", totalScore: -1 },
+        ])}
+      />,
+    );
+
+    // New order: A (2), B (1), C (-1)
+    items = screen.getAllByTestId("track-item");
+    expect(items[0]).toHaveAttribute("data-trackid", "track-A");
+    expect(items[1]).toHaveAttribute("data-trackid", "track-B");
+    expect(items[2]).toHaveAttribute("data-trackid", "track-C");
+  });
+
+  it("promotes a track above higher-scored tracks when its score surpasses them after a vote", () => {
+    const { rerender } = render(
+      <QueueTrackList
+        tracks={makeTracks([
+          { trackId: "track-A", totalScore: 2 },
+          { trackId: "track-B", totalScore: 0 },
+          { trackId: "track-C", totalScore: -1 },
+        ])}
+      />,
+    );
+
+    // Simulate track-B being upvoted three times to score 3 — should jump above track-A
+    rerender(
+      <QueueTrackList
+        tracks={makeTracks([
+          { trackId: "track-A", totalScore: 2 },
+          { trackId: "track-B", totalScore: 3 },
+          { trackId: "track-C", totalScore: -1 },
+        ])}
+      />,
+    );
+
+    const items = screen.getAllByTestId("track-item");
+    expect(items[0]).toHaveAttribute("data-trackid", "track-B");
+    expect(items[1]).toHaveAttribute("data-trackid", "track-A");
+    expect(items[2]).toHaveAttribute("data-trackid", "track-C");
+  });
+
+  /**
+   * Scenario: Currently playing track stays at top regardless of score
+   *   The currently playing track is excluded from the upcoming queue list
+   *   (filtered out by $pin.tsx before being passed to QueueTrackList).
+   *   QueueTrackList should not render a track whose trackId matches currentlyPlayingId
+   *   even if it is present in the passed tracks array.
+   *
+   *   Note: In production, $pin.tsx filters out the currently playing track before
+   *   passing to QueueTrackList. This test verifies QueueTrackList's own defensive
+   *   behaviour: it disables vote buttons for the currentlyPlayingId track but still
+   *   renders it — the exclusion responsibility belongs to the parent.
+   */
+  it("does not include the currently playing track in the sorted queue when parent excludes it", () => {
+    // Simulate what $pin.tsx does: exclude currentlyPlayingId from the tracks prop
+    const currentlyPlayingId = "track-X";
+    const upcomingTracks = makeTracks([
+      { trackId: "track-A", totalScore: 2 },
+      { trackId: "track-B", totalScore: 0 },
+      { trackId: "track-C", totalScore: -1 },
+    ]);
+
+    render(
+      <QueueTrackList
+        tracks={upcomingTracks}
+        currentlyPlayingId={currentlyPlayingId}
+      />,
+    );
+
+    const items = screen.getAllByTestId("track-item");
+    const renderedIds = items.map((el) => el.getAttribute("data-trackid"));
+
+    expect(renderedIds).not.toContain(currentlyPlayingId);
+    expect(renderedIds).toEqual(["track-A", "track-B", "track-C"]);
+  });
+
+  it("updated scores are reflected in rendered score elements after a vote", () => {
+    const { rerender } = render(
+      <QueueTrackList
+        tracks={makeTracks([
+          { trackId: "track-A", totalScore: 2 },
+          { trackId: "track-B", totalScore: 0 },
+        ])}
+      />,
+    );
+
+    expect(screen.getByTestId("queue-track-score-track-B")).toHaveTextContent("0");
+
+    // After upvote, score updates
+    rerender(
+      <QueueTrackList
+        tracks={makeTracks([
+          { trackId: "track-A", totalScore: 2 },
+          { trackId: "track-B", totalScore: 1 },
+        ])}
+      />,
+    );
+
+    expect(screen.getByTestId("queue-track-score-track-B")).toHaveTextContent("1");
+  });
+});
+
 describe("QueueTrackList — onVote callback (Task #71)", () => {
   /**
    * Scenario: Guest casts an upvote

--- a/apps/web/src/components/QueueTrackList.test.tsx
+++ b/apps/web/src/components/QueueTrackList.test.tsx
@@ -5,8 +5,8 @@
  * Scenario: Already-played tracks are excluded from the queue
  * Scenario: Currently playing track is excluded from the queue
  */
-import { describe, it, expect } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within, fireEvent } from "@testing-library/react";
 import React from "react";
 import { QueueTrackList } from "./QueueTrackList";
 
@@ -242,5 +242,84 @@ describe("QueueTrackList", () => {
 
     expect(screen.getByTestId("upvote-track-789")).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByTestId("downvote-track-789")).toHaveAttribute("aria-pressed", "false");
+  });
+});
+
+describe("QueueTrackList — onVote callback (Task #71)", () => {
+  /**
+   * Scenario: Guest casts an upvote
+   *   When I click the upvote button on a track
+   *   Then onVote is called with (trackId, 1)
+   */
+  it("calls onVote with (trackId, 1) when upvote button is clicked", () => {
+    const onVote = vi.fn();
+    render(
+      <QueueTrackList
+        isAuthenticated
+        tracks={[{ trackId: "track-a", totalScore: 0, hasBeenPlayed: false, durationMs: 180000 }]}
+        onVote={onVote}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("upvote-track-a"));
+
+    expect(onVote).toHaveBeenCalledWith("track-a", 1);
+    expect(onVote).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * Scenario: Guest casts a downvote
+   *   When I click the downvote button on a track
+   *   Then onVote is called with (trackId, -1)
+   */
+  it("calls onVote with (trackId, -1) when downvote button is clicked", () => {
+    const onVote = vi.fn();
+    render(
+      <QueueTrackList
+        isAuthenticated
+        tracks={[{ trackId: "track-b", totalScore: 0, hasBeenPlayed: false, durationMs: 180000 }]}
+        onVote={onVote}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("downvote-track-b"));
+
+    expect(onVote).toHaveBeenCalledWith("track-b", -1);
+    expect(onVote).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * onVote is not called when button is disabled (currently playing track)
+   */
+  it("does not call onVote when voting on the currently playing track (buttons are disabled)", () => {
+    const onVote = vi.fn();
+    render(
+      <QueueTrackList
+        isAuthenticated
+        currentlyPlayingId="track-c"
+        tracks={[{ trackId: "track-c", totalScore: 0, hasBeenPlayed: false, durationMs: 180000 }]}
+        onVote={onVote}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("upvote-track-c"));
+
+    expect(onVote).not.toHaveBeenCalled();
+  });
+
+  /**
+   * onVote is optional — component renders without it
+   */
+  it("renders without errors when onVote is not provided", () => {
+    render(
+      <QueueTrackList
+        isAuthenticated
+        tracks={[{ trackId: "track-d", totalScore: 0, hasBeenPlayed: false, durationMs: 180000 }]}
+      />,
+    );
+
+    // Should not throw — clicking still works
+    fireEvent.click(screen.getByTestId("upvote-track-d"));
+    expect(screen.getByTestId("upvote-track-d")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/QueueTrackList.test.tsx
+++ b/apps/web/src/components/QueueTrackList.test.tsx
@@ -128,4 +128,55 @@ describe("QueueTrackList", () => {
     expect(list).toBeInTheDocument();
     expect(screen.queryAllByTestId("track-item")).toHaveLength(0);
   });
+
+  /**
+   * Scenario: Signed-in guest sees vote controls on queued tracks
+   *   Given I am signed in as a Party Guest
+   *   And the Fissa has queued tracks
+   *   When I view the Queue
+   *   Then each queued track row shows an upvote button
+   *   And each queued track row shows a downvote button
+   */
+  it("shows upvote and downvote buttons for each track when isAuthenticated=true", () => {
+    render(
+      <QueueTrackList
+        isAuthenticated
+        tracks={makeTracks([
+          { trackId: "track-a", totalScore: 1 },
+          { trackId: "track-b", totalScore: 2 },
+        ])}
+      />,
+    );
+
+    expect(screen.getByTestId("upvote-track-a")).toBeInTheDocument();
+    expect(screen.getByTestId("downvote-track-a")).toBeInTheDocument();
+    expect(screen.getByTestId("upvote-track-b")).toBeInTheDocument();
+    expect(screen.getByTestId("downvote-track-b")).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: "Upvote track-a" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Downvote track-a" })).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Unauthenticated guest does not see vote controls
+   *   Given I am not signed in
+   *   And the Fissa has queued tracks
+   *   When I view the Queue
+   *   Then no upvote or downvote buttons are visible
+   */
+  it("does not show upvote or downvote buttons when isAuthenticated=false", () => {
+    render(
+      <QueueTrackList
+        tracks={makeTracks([
+          { trackId: "track-a", totalScore: 1 },
+          { trackId: "track-b", totalScore: 2 },
+        ])}
+      />,
+    );
+
+    expect(screen.queryByTestId("upvote-track-a")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("downvote-track-a")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("upvote-track-b")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("downvote-track-b")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/QueueTrackList.test.tsx
+++ b/apps/web/src/components/QueueTrackList.test.tsx
@@ -179,4 +179,21 @@ describe("QueueTrackList", () => {
     expect(screen.queryByTestId("upvote-track-b")).not.toBeInTheDocument();
     expect(screen.queryByTestId("downvote-track-b")).not.toBeInTheDocument();
   });
+
+  it("disables vote buttons for currently playing track", () => {
+    render(
+      <QueueTrackList
+        isAuthenticated
+        currentlyPlayingId="track-a"
+        tracks={makeTracks([
+          { trackId: "track-a", totalScore: 1 },
+          { trackId: "track-b", totalScore: 0 },
+        ])}
+      />,
+    );
+    expect(screen.getByTestId("upvote-track-a")).toBeDisabled();
+    expect(screen.getByTestId("downvote-track-a")).toBeDisabled();
+    expect(screen.getByTestId("upvote-track-b")).not.toBeDisabled();
+    expect(screen.getByTestId("downvote-track-b")).not.toBeDisabled();
+  });
 });

--- a/apps/web/src/components/QueueTrackList.test.tsx
+++ b/apps/web/src/components/QueueTrackList.test.tsx
@@ -130,196 +130,84 @@ describe("QueueTrackList", () => {
   });
 
   /**
-   * Scenario: Signed-in guest sees vote controls on queued tracks
-   *   Given I am signed in as a Party Guest
-   *   And the Fissa has queued tracks
-   *   When I view the Queue
-   *   Then each queued track row shows an upvote button
-   *   And each queued track row shows a downvote button
+   * Scenario: Vote error indicator and retry button
    */
-  it("shows upvote and downvote buttons for each track when isAuthenticated=true", () => {
-    render(
-      <QueueTrackList
-        isAuthenticated
-        tracks={makeTracks([
-          { trackId: "track-a", totalScore: 1 },
-          { trackId: "track-b", totalScore: 2 },
-        ])}
-      />,
-    );
+  describe("vote error indicator and retry (Task #78)", () => {
+    it("shows vote error indicator when voteErrors has the trackId", () => {
+      const voteErrors = new Map([["track-a", { vote: 1 as const }]]);
+      render(
+        <QueueTrackList
+          tracks={makeTracks([{ trackId: "track-a", totalScore: 3 }])}
+          voteErrors={voteErrors}
+        />,
+      );
 
-    expect(screen.getByTestId("upvote-track-a")).toBeInTheDocument();
-    expect(screen.getByTestId("downvote-track-a")).toBeInTheDocument();
-    expect(screen.getByTestId("upvote-track-b")).toBeInTheDocument();
-    expect(screen.getByTestId("downvote-track-b")).toBeInTheDocument();
+      expect(screen.getByTestId("vote-error-track-a")).toBeInTheDocument();
+    });
 
-    expect(screen.getByRole("button", { name: "Upvote track-a" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Downvote track-a" })).toBeInTheDocument();
-  });
+    it("shows retry button when voteErrors has the trackId", () => {
+      const voteErrors = new Map([["track-a", { vote: 1 as const }]]);
+      render(
+        <QueueTrackList
+          tracks={makeTracks([{ trackId: "track-a", totalScore: 3 }])}
+          voteErrors={voteErrors}
+        />,
+      );
 
-  /**
-   * Scenario: Unauthenticated guest does not see vote controls
-   *   Given I am not signed in
-   *   And the Fissa has queued tracks
-   *   When I view the Queue
-   *   Then no upvote or downvote buttons are visible
-   */
-  it("does not show upvote or downvote buttons when isAuthenticated=false", () => {
-    render(
-      <QueueTrackList
-        tracks={makeTracks([
-          { trackId: "track-a", totalScore: 1 },
-          { trackId: "track-b", totalScore: 2 },
-        ])}
-      />,
-    );
+      expect(screen.getByTestId("retry-vote-track-a")).toBeInTheDocument();
+    });
 
-    expect(screen.queryByTestId("upvote-track-a")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("downvote-track-a")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("upvote-track-b")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("downvote-track-b")).not.toBeInTheDocument();
-  });
+    it("does not show error indicator or retry button when voteErrors is empty", () => {
+      render(
+        <QueueTrackList
+          tracks={makeTracks([{ trackId: "track-a", totalScore: 3 }])}
+          voteErrors={new Map()}
+        />,
+      );
 
-  it("disables vote buttons for currently playing track", () => {
-    render(
-      <QueueTrackList
-        isAuthenticated
-        currentlyPlayingId="track-a"
-        tracks={makeTracks([
-          { trackId: "track-a", totalScore: 1 },
-          { trackId: "track-b", totalScore: 0 },
-        ])}
-      />,
-    );
-    expect(screen.getByTestId("upvote-track-a")).toBeDisabled();
-    expect(screen.getByTestId("downvote-track-a")).toBeDisabled();
-    expect(screen.getByTestId("upvote-track-b")).not.toBeDisabled();
-    expect(screen.getByTestId("downvote-track-b")).not.toBeDisabled();
-  });
+      expect(screen.queryByTestId("vote-error-track-a")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("retry-vote-track-a")).not.toBeInTheDocument();
+    });
 
-  /**
-   * Scenario: Guest's previously cast upvote is shown on load (#69)
-   *   Given I am signed in as a Party Guest and I previously upvoted track "track-123"
-   *   When I load the Fissa page
-   *   Then the upvote button for "track-123" shows as active/selected (aria-pressed=true)
-   */
-  it("marks upvote button as aria-pressed=true when user previously upvoted", () => {
-    const userVotes = new Map<string, 1 | -1>([["track-123", 1]]);
-    render(
-      <QueueTrackList
-        tracks={makeTracks([{ trackId: "track-123", totalScore: 3 }])}
-        isAuthenticated
-        userVotes={userVotes}
-      />,
-    );
+    it("does not show error indicator when voteErrors prop is not provided", () => {
+      render(
+        <QueueTrackList tracks={makeTracks([{ trackId: "track-a", totalScore: 3 }])} />,
+      );
 
-    expect(screen.getByTestId("upvote-track-123")).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByTestId("downvote-track-123")).toHaveAttribute("aria-pressed", "false");
-  });
+      expect(screen.queryByTestId("vote-error-track-a")).not.toBeInTheDocument();
+    });
 
-  it("marks downvote button as aria-pressed=true when user previously downvoted", () => {
-    const userVotes = new Map<string, 1 | -1>([["track-456", -1]]);
-    render(
-      <QueueTrackList
-        tracks={makeTracks([{ trackId: "track-456", totalScore: -1 }])}
-        isAuthenticated
-        userVotes={userVotes}
-      />,
-    );
+    it("calls onRetryVote with trackId and vote when retry button is clicked", () => {
+      const voteErrors = new Map([["track-a", { vote: 1 as const }]]);
+      const onRetryVote = vi.fn();
+      render(
+        <QueueTrackList
+          tracks={makeTracks([{ trackId: "track-a", totalScore: 3 }])}
+          voteErrors={voteErrors}
+          onRetryVote={onRetryVote}
+        />,
+      );
 
-    expect(screen.getByTestId("upvote-track-456")).toHaveAttribute("aria-pressed", "false");
-    expect(screen.getByTestId("downvote-track-456")).toHaveAttribute("aria-pressed", "true");
-  });
+      fireEvent.click(screen.getByTestId("retry-vote-track-a"));
 
-  it("shows both vote buttons as aria-pressed=false when user has not voted on track", () => {
-    render(
-      <QueueTrackList
-        tracks={makeTracks([{ trackId: "track-789", totalScore: 0 }])}
-        isAuthenticated
-        userVotes={new Map()}
-      />,
-    );
+      expect(onRetryVote).toHaveBeenCalledWith("track-a", 1);
+    });
 
-    expect(screen.getByTestId("upvote-track-789")).toHaveAttribute("aria-pressed", "false");
-    expect(screen.getByTestId("downvote-track-789")).toHaveAttribute("aria-pressed", "false");
-  });
-});
+    it("only shows error for tracks with errors, not for tracks without errors", () => {
+      const voteErrors = new Map([["track-a", { vote: -1 as const }]]);
+      render(
+        <QueueTrackList
+          tracks={makeTracks([
+            { trackId: "track-a", totalScore: 3 },
+            { trackId: "track-b", totalScore: 1 },
+          ])}
+          voteErrors={voteErrors}
+        />,
+      );
 
-describe("QueueTrackList — onVote callback (Task #71)", () => {
-  /**
-   * Scenario: Guest casts an upvote
-   *   When I click the upvote button on a track
-   *   Then onVote is called with (trackId, 1)
-   */
-  it("calls onVote with (trackId, 1) when upvote button is clicked", () => {
-    const onVote = vi.fn();
-    render(
-      <QueueTrackList
-        isAuthenticated
-        tracks={[{ trackId: "track-a", totalScore: 0, hasBeenPlayed: false, durationMs: 180000 }]}
-        onVote={onVote}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId("upvote-track-a"));
-
-    expect(onVote).toHaveBeenCalledWith("track-a", 1);
-    expect(onVote).toHaveBeenCalledTimes(1);
-  });
-
-  /**
-   * Scenario: Guest casts a downvote
-   *   When I click the downvote button on a track
-   *   Then onVote is called with (trackId, -1)
-   */
-  it("calls onVote with (trackId, -1) when downvote button is clicked", () => {
-    const onVote = vi.fn();
-    render(
-      <QueueTrackList
-        isAuthenticated
-        tracks={[{ trackId: "track-b", totalScore: 0, hasBeenPlayed: false, durationMs: 180000 }]}
-        onVote={onVote}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId("downvote-track-b"));
-
-    expect(onVote).toHaveBeenCalledWith("track-b", -1);
-    expect(onVote).toHaveBeenCalledTimes(1);
-  });
-
-  /**
-   * onVote is not called when button is disabled (currently playing track)
-   */
-  it("does not call onVote when voting on the currently playing track (buttons are disabled)", () => {
-    const onVote = vi.fn();
-    render(
-      <QueueTrackList
-        isAuthenticated
-        currentlyPlayingId="track-c"
-        tracks={[{ trackId: "track-c", totalScore: 0, hasBeenPlayed: false, durationMs: 180000 }]}
-        onVote={onVote}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId("upvote-track-c"));
-
-    expect(onVote).not.toHaveBeenCalled();
-  });
-
-  /**
-   * onVote is optional — component renders without it
-   */
-  it("renders without errors when onVote is not provided", () => {
-    render(
-      <QueueTrackList
-        isAuthenticated
-        tracks={[{ trackId: "track-d", totalScore: 0, hasBeenPlayed: false, durationMs: 180000 }]}
-      />,
-    );
-
-    // Should not throw — clicking still works
-    fireEvent.click(screen.getByTestId("upvote-track-d"));
-    expect(screen.getByTestId("upvote-track-d")).toBeInTheDocument();
+      expect(screen.getByTestId("vote-error-track-a")).toBeInTheDocument();
+      expect(screen.queryByTestId("vote-error-track-b")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("retry-vote-track-b")).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/QueueTrackList.test.tsx
+++ b/apps/web/src/components/QueueTrackList.test.tsx
@@ -196,4 +196,51 @@ describe("QueueTrackList", () => {
     expect(screen.getByTestId("upvote-track-b")).not.toBeDisabled();
     expect(screen.getByTestId("downvote-track-b")).not.toBeDisabled();
   });
+
+  /**
+   * Scenario: Guest's previously cast upvote is shown on load (#69)
+   *   Given I am signed in as a Party Guest and I previously upvoted track "track-123"
+   *   When I load the Fissa page
+   *   Then the upvote button for "track-123" shows as active/selected (aria-pressed=true)
+   */
+  it("marks upvote button as aria-pressed=true when user previously upvoted", () => {
+    const userVotes = new Map<string, 1 | -1>([["track-123", 1]]);
+    render(
+      <QueueTrackList
+        tracks={makeTracks([{ trackId: "track-123", totalScore: 3 }])}
+        isAuthenticated
+        userVotes={userVotes}
+      />,
+    );
+
+    expect(screen.getByTestId("upvote-track-123")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("downvote-track-123")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("marks downvote button as aria-pressed=true when user previously downvoted", () => {
+    const userVotes = new Map<string, 1 | -1>([["track-456", -1]]);
+    render(
+      <QueueTrackList
+        tracks={makeTracks([{ trackId: "track-456", totalScore: -1 }])}
+        isAuthenticated
+        userVotes={userVotes}
+      />,
+    );
+
+    expect(screen.getByTestId("upvote-track-456")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("downvote-track-456")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows both vote buttons as aria-pressed=false when user has not voted on track", () => {
+    render(
+      <QueueTrackList
+        tracks={makeTracks([{ trackId: "track-789", totalScore: 0 }])}
+        isAuthenticated
+        userVotes={new Map()}
+      />,
+    );
+
+    expect(screen.getByTestId("upvote-track-789")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("downvote-track-789")).toHaveAttribute("aria-pressed", "false");
+  });
 });

--- a/apps/web/src/components/QueueTrackList.tsx
+++ b/apps/web/src/components/QueueTrackList.tsx
@@ -12,6 +12,7 @@ interface QueueTrackListProps {
   isAuthenticated?: boolean;
   currentlyPlayingId?: string;
   userVotes?: Map<string, 1 | -1>;
+  onVote?: (trackId: string, score: 1 | -1) => void;
 }
 
 /**
@@ -19,7 +20,7 @@ interface QueueTrackListProps {
  * Each track shows artwork (Spotify CDN), track identifier, and vote tally.
  * Defensively filters out already-played tracks.
  */
-export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticated = false, currentlyPlayingId, userVotes }) => {
+export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticated = false, currentlyPlayingId, userVotes, onVote }) => {
   const sorted = [...tracks]
     .filter((t) => !t.hasBeenPlayed)
     .sort((a, b) => b.totalScore - a.totalScore);
@@ -70,6 +71,7 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticate
                   aria-pressed={userVote === 1}
                   type="button"
                   disabled={track.trackId === currentlyPlayingId}
+                  onClick={() => onVote?.(track.trackId, 1)}
                 >
                   +1
                 </button>
@@ -79,6 +81,7 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticate
                   aria-pressed={userVote === -1}
                   type="button"
                   disabled={track.trackId === currentlyPlayingId}
+                  onClick={() => onVote?.(track.trackId, -1)}
                 >
                   -1
                 </button>

--- a/apps/web/src/components/QueueTrackList.tsx
+++ b/apps/web/src/components/QueueTrackList.tsx
@@ -9,6 +9,7 @@ interface QueueTrack {
 
 interface QueueTrackListProps {
   tracks: QueueTrack[];
+  isAuthenticated?: boolean;
 }
 
 /**
@@ -16,7 +17,7 @@ interface QueueTrackListProps {
  * Each track shows artwork (Spotify CDN), track identifier, and vote tally.
  * Defensively filters out already-played tracks.
  */
-export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks }) => {
+export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticated = false }) => {
   const sorted = [...tracks]
     .filter((t) => !t.hasBeenPlayed)
     .sort((a, b) => b.totalScore - a.totalScore);
@@ -57,6 +58,25 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks }) => {
             >
               {track.totalScore}
             </span>
+
+            {isAuthenticated && (
+              <div className="flex gap-1">
+                <button
+                  aria-label={`Upvote ${track.trackId}`}
+                  data-testid={`upvote-${track.trackId}`}
+                  type="button"
+                >
+                  +1
+                </button>
+                <button
+                  aria-label={`Downvote ${track.trackId}`}
+                  data-testid={`downvote-${track.trackId}`}
+                  type="button"
+                >
+                  -1
+                </button>
+              </div>
+            )}
           </li>
         );
       })}

--- a/apps/web/src/components/QueueTrackList.tsx
+++ b/apps/web/src/components/QueueTrackList.tsx
@@ -10,6 +10,7 @@ interface QueueTrack {
 interface QueueTrackListProps {
   tracks: QueueTrack[];
   isAuthenticated?: boolean;
+  currentlyPlayingId?: string;
 }
 
 /**
@@ -17,7 +18,7 @@ interface QueueTrackListProps {
  * Each track shows artwork (Spotify CDN), track identifier, and vote tally.
  * Defensively filters out already-played tracks.
  */
-export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticated = false }) => {
+export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticated = false, currentlyPlayingId }) => {
   const sorted = [...tracks]
     .filter((t) => !t.hasBeenPlayed)
     .sort((a, b) => b.totalScore - a.totalScore);
@@ -65,6 +66,7 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticate
                   aria-label={`Upvote ${track.trackId}`}
                   data-testid={`upvote-${track.trackId}`}
                   type="button"
+                  disabled={track.trackId === currentlyPlayingId}
                 >
                   +1
                 </button>
@@ -72,6 +74,7 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticate
                   aria-label={`Downvote ${track.trackId}`}
                   data-testid={`downvote-${track.trackId}`}
                   type="button"
+                  disabled={track.trackId === currentlyPlayingId}
                 >
                   -1
                 </button>

--- a/apps/web/src/components/QueueTrackList.tsx
+++ b/apps/web/src/components/QueueTrackList.tsx
@@ -11,6 +11,7 @@ interface QueueTrackListProps {
   tracks: QueueTrack[];
   isAuthenticated?: boolean;
   currentlyPlayingId?: string;
+  userVotes?: Map<string, 1 | -1>;
 }
 
 /**
@@ -18,7 +19,7 @@ interface QueueTrackListProps {
  * Each track shows artwork (Spotify CDN), track identifier, and vote tally.
  * Defensively filters out already-played tracks.
  */
-export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticated = false, currentlyPlayingId }) => {
+export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticated = false, currentlyPlayingId, userVotes }) => {
   const sorted = [...tracks]
     .filter((t) => !t.hasBeenPlayed)
     .sort((a, b) => b.totalScore - a.totalScore);
@@ -27,6 +28,7 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticate
     <ul data-testid="track-list" className="flex flex-col gap-3">
       {sorted.map((track) => {
         const artworkUrl = `https://i.scdn.co/image/ab67616d00004851${track.trackId}`;
+        const userVote = userVotes?.get(track.trackId);
 
         return (
           <li
@@ -65,6 +67,7 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticate
                 <button
                   aria-label={`Upvote ${track.trackId}`}
                   data-testid={`upvote-${track.trackId}`}
+                  aria-pressed={userVote === 1}
                   type="button"
                   disabled={track.trackId === currentlyPlayingId}
                 >
@@ -73,6 +76,7 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticate
                 <button
                   aria-label={`Downvote ${track.trackId}`}
                   data-testid={`downvote-${track.trackId}`}
+                  aria-pressed={userVote === -1}
                   type="button"
                   disabled={track.trackId === currentlyPlayingId}
                 >

--- a/apps/web/src/components/QueueTrackList.tsx
+++ b/apps/web/src/components/QueueTrackList.tsx
@@ -13,6 +13,8 @@ interface QueueTrackListProps {
   currentlyPlayingId?: string;
   userVotes?: Map<string, 1 | -1>;
   onVote?: (trackId: string, score: 1 | -1) => void;
+  voteErrors?: Map<string, { vote: 1 | -1 }>;
+  onRetryVote?: (trackId: string, vote: 1 | -1) => void;
 }
 
 /**
@@ -20,7 +22,7 @@ interface QueueTrackListProps {
  * Each track shows artwork (Spotify CDN), track identifier, and vote tally.
  * Defensively filters out already-played tracks.
  */
-export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticated = false, currentlyPlayingId, userVotes, onVote }) => {
+export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticated = false, currentlyPlayingId, userVotes, onVote, voteErrors, onRetryVote }) => {
   const sorted = [...tracks]
     .filter((t) => !t.hasBeenPlayed)
     .sort((a, b) => b.totalScore - a.totalScore);
@@ -86,6 +88,29 @@ export const QueueTrackList: FC<QueueTrackListProps> = ({ tracks, isAuthenticate
                   -1
                 </button>
               </div>
+            )}
+
+            {voteErrors?.has(track.trackId) && (
+              <>
+                <span
+                  data-testid={`vote-error-${track.trackId}`}
+                  className="text-xs text-destructive"
+                  role="alert"
+                >
+                  Vote failed
+                </span>
+                <button
+                  data-testid={`retry-vote-${track.trackId}`}
+                  type="button"
+                  className="text-xs underline"
+                  onClick={() => {
+                    const voteError = voteErrors.get(track.trackId);
+                    if (voteError) onRetryVote?.(track.trackId, voteError.vote);
+                  }}
+                >
+                  Retry
+                </button>
+              </>
             )}
           </li>
         );

--- a/apps/web/src/hooks/useDebounce.ts
+++ b/apps/web/src/hooks/useDebounce.ts
@@ -1,0 +1,10 @@
+import { useState, useEffect } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+  return debounced;
+}

--- a/apps/web/src/hooks/useTrackSearch.test.ts
+++ b/apps/web/src/hooks/useTrackSearch.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for useTrackSearch hook (Task #72)
+ *
+ * Scenario: Typing triggers a debounced search
+ * Scenario: Empty query does not trigger search
+ * Scenario: Loading state is shown during search
+ * Scenario: Results populate after search completes
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+// Mock useDebounce to pass values through synchronously in tests
+vi.mock("~/hooks/useDebounce", () => ({
+  useDebounce: (value: unknown) => value,
+}));
+
+const mockUseQuery = vi.fn();
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    spotify: {
+      searchTracks: {
+        useQuery: (...args: unknown[]) => mockUseQuery(...args),
+      },
+    },
+  },
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+import { useTrackSearch } from "./useTrackSearch";
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("useTrackSearch (Task #72)", () => {
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+  });
+
+  /**
+   * Scenario: Empty query does not trigger search
+   *   Given the search field is empty
+   *   Then no Spotify search is performed (enabled=false)
+   */
+  it("does not enable the query when query is empty", () => {
+    renderHook(() => useTrackSearch());
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  /**
+   * Scenario: Whitespace-only query does not trigger search
+   */
+  it("does not enable the query when query is whitespace only", () => {
+    const { result } = renderHook(() => useTrackSearch());
+
+    act(() => {
+      result.current.setQuery("   ");
+    });
+
+    expect(mockUseQuery).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  /**
+   * Scenario: Typing triggers a debounced search
+   *   Given I type "Bohemian" in the search field
+   *   And I stop typing for 300ms
+   *   Then a Spotify search is performed for "Bohemian"
+   */
+  it("enables the query when query is non-empty", () => {
+    const { result } = renderHook(() => useTrackSearch());
+
+    act(() => {
+      result.current.setQuery("Bohemian");
+    });
+
+    expect(mockUseQuery).toHaveBeenLastCalledWith(
+      { query: "Bohemian" },
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+
+  /**
+   * Scenario: Loading state is shown during search
+   *   Given I have typed a search query
+   *   When the Spotify search is in-flight
+   *   Then isLoading is true
+   */
+  it("returns isLoading=true when query is non-empty and search is in-flight", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() => useTrackSearch());
+
+    act(() => {
+      result.current.setQuery("Bohemian");
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  /**
+   * Scenario: isLoading is false when query is empty even if hook returns loading
+   */
+  it("returns isLoading=false when query is empty regardless of API state", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() => useTrackSearch());
+
+    // query is empty by default
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  /**
+   * Scenario: Results populate after search completes
+   *   Given I typed "Bohemian" and the search completed
+   *   Then a list of track results is returned
+   */
+  it("returns results when search data is available", () => {
+    const tracks = [
+      { id: "t1", name: "Bohemian Rhapsody", artists: ["Queen"], albumArt: "https://img/t1.jpg" },
+    ];
+    mockUseQuery.mockReturnValue({ data: { tracks }, isLoading: false });
+
+    const { result } = renderHook(() => useTrackSearch());
+
+    act(() => {
+      result.current.setQuery("Bohemian");
+    });
+
+    expect(result.current.results).toEqual(tracks);
+  });
+
+  /**
+   * Exposes query and setQuery
+   */
+  it("exposes query and setQuery", () => {
+    const { result } = renderHook(() => useTrackSearch());
+
+    expect(result.current.query).toBe("");
+    act(() => {
+      result.current.setQuery("test");
+    });
+    expect(result.current.query).toBe("test");
+  });
+});

--- a/apps/web/src/hooks/useTrackSearch.ts
+++ b/apps/web/src/hooks/useTrackSearch.ts
@@ -1,0 +1,24 @@
+import { api } from "~/utils/api";
+import { useDebounce } from "./useDebounce";
+import { useState } from "react";
+import type { SearchTrack } from "~/components/AddTrackSheet";
+
+/**
+ * Custom hook wrapping the Spotify search tRPC query with debounce logic.
+ * Never fires for empty / whitespace-only queries.
+ *
+ * Exposes { results, isLoading, query, setQuery }
+ */
+export function useTrackSearch(debounceMs = 300) {
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebounce(query.trim(), debounceMs);
+
+  const { data, isLoading } = api.spotify.searchTracks.useQuery(
+    { query: debouncedQuery },
+    { enabled: debouncedQuery.length > 0 },
+  );
+
+  const results: SearchTrack[] = data?.tracks ?? [];
+
+  return { results, isLoading: debouncedQuery.length > 0 && isLoading, query, setQuery };
+}

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -7,7 +7,7 @@
  * Scenario: Authenticated user does not see Sign in CTA (Task #58)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import React from "react";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -1635,5 +1635,147 @@ describe("/fissa/$pin — Wire vote.create mutation (Task #71)", () => {
 
     expect(mockInvalidateVotes).toHaveBeenCalledWith({ pin: "ABC123" });
     expect(mockInvalidateFissa).toHaveBeenCalledWith("ABC123");
+  });
+});
+
+describe("/fissa/$pin — Vote error rollback and retry (Task #78)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockVoteByFissaFromUser = vi.mocked(api.vote.byFissaFromUser.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+  const mockCreateVoteMutation = vi.mocked(api.vote.create.useMutation);
+
+  const activeFissaWithTracks = {
+    pin: "1234",
+    currentlyPlayingId: null,
+    tracks: [
+      { trackId: "sweet-child", hasBeenPlayed: false, durationMs: 356000, score: 0, totalScore: 5 },
+      { trackId: "macarena", hasBeenPlayed: false, durationMs: 230000, score: 0, totalScore: 3 },
+    ],
+  };
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({ data: activeFissaWithTracks, isLoading: false, isError: false, error: null } as any);
+    mockVoteByFissaFromUser.mockReturnValue({ data: [] } as any);
+    mockUseSession.mockReturnValue({ data: { user: { id: "user1", name: "Guest" } }, isPending: false } as any);
+  });
+
+  /**
+   * Scenario: Network error rolls back optimistic update
+   *   When onError is called, error indicator and retry button appear
+   */
+  it("shows error indicator and retry button after vote failure", () => {
+    let capturedOnError: ((err: unknown, vars: { trackId: string; vote: number; pin: string }, ctx: unknown) => void) | undefined;
+    let capturedOnMutate: ((vars: { trackId: string; vote: number; pin: string }) => unknown) | undefined;
+    mockCreateVoteMutation.mockImplementation((callbacks: any) => {
+      capturedOnError = callbacks?.onError;
+      capturedOnMutate = callbacks?.onMutate;
+      return { mutate: vi.fn() };
+    });
+
+    render(<QueuePage pin="1234" />);
+
+    const ctx = capturedOnMutate?.({ trackId: "sweet-child", vote: 1, pin: "1234" });
+
+    act(() => {
+      capturedOnError?.(
+        { data: { code: "INTERNAL_SERVER_ERROR" } },
+        { trackId: "sweet-child", vote: 1, pin: "1234" },
+        ctx,
+      );
+    });
+
+    expect(screen.getByTestId("vote-error-sweet-child")).toBeInTheDocument();
+    expect(screen.getByTestId("retry-vote-sweet-child")).toBeInTheDocument();
+  });
+
+  /**
+   * Scenario: Guest retries after error and succeeds
+   *   Clicking retry button calls createVote again with the same vote
+   */
+  it("calls createVote mutate when retry button is clicked", () => {
+    const mockMutate = vi.fn();
+    let capturedOnError: ((err: unknown, vars: { trackId: string; vote: number; pin: string }, ctx: unknown) => void) | undefined;
+    let capturedOnMutate: ((vars: { trackId: string; vote: number; pin: string }) => unknown) | undefined;
+    mockCreateVoteMutation.mockImplementation((callbacks: any) => {
+      capturedOnError = callbacks?.onError;
+      capturedOnMutate = callbacks?.onMutate;
+      return { mutate: mockMutate };
+    });
+
+    render(<QueuePage pin="1234" />);
+
+    const ctx = capturedOnMutate?.({ trackId: "sweet-child", vote: 1, pin: "1234" });
+    act(() => {
+      capturedOnError?.(
+        { data: { code: "INTERNAL_SERVER_ERROR" } },
+        { trackId: "sweet-child", vote: 1, pin: "1234" },
+        ctx,
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("retry-vote-sweet-child"));
+
+    expect(mockMutate).toHaveBeenCalledWith(expect.objectContaining({ trackId: "sweet-child", vote: 1, pin: "1234" }));
+  });
+
+  /**
+   * Scenario: Voting on a removed track refreshes the Queue
+   *   When NOT_FOUND error, fissa.byId is invalidated
+   */
+  it("invalidates fissa.byId when vote returns NOT_FOUND error", () => {
+    const mockInvalidateFissa = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(api.useUtils).mockReturnValue({
+      vote: { byFissaFromUser: { invalidate: vi.fn().mockResolvedValue(undefined) } },
+      fissa: { byId: { invalidate: mockInvalidateFissa } },
+    } as any);
+
+    let capturedOnError: ((err: unknown, vars: { trackId: string; vote: number; pin: string }, ctx: unknown) => void) | undefined;
+    let capturedOnMutate: ((vars: { trackId: string; vote: number; pin: string }) => unknown) | undefined;
+    mockCreateVoteMutation.mockImplementation((callbacks: any) => {
+      capturedOnError = callbacks?.onError;
+      capturedOnMutate = callbacks?.onMutate;
+      return { mutate: vi.fn() };
+    });
+
+    render(<QueuePage pin="1234" />);
+
+    const ctx = capturedOnMutate?.({ trackId: "macarena", vote: 1, pin: "1234" });
+    act(() => {
+      capturedOnError?.(
+        { data: { code: "NOT_FOUND" } },
+        { trackId: "macarena", vote: 1, pin: "1234" },
+        ctx,
+      );
+    });
+
+    expect(mockInvalidateFissa).toHaveBeenCalledWith("1234");
+  });
+
+  /**
+   * Error indicator clears after successful vote
+   */
+  it("removes error indicator after successful vote", () => {
+    let capturedOnError: ((err: unknown, vars: { trackId: string; vote: number; pin: string }, ctx: unknown) => void) | undefined;
+    let capturedOnSuccess: ((data: unknown, vars: { trackId: string; vote: number; pin: string }, ctx: unknown) => void) | undefined;
+    let capturedOnMutate: ((vars: { trackId: string; vote: number; pin: string }) => unknown) | undefined;
+    mockCreateVoteMutation.mockImplementation((callbacks: any) => {
+      capturedOnError = callbacks?.onError;
+      capturedOnSuccess = callbacks?.onSuccess;
+      capturedOnMutate = callbacks?.onMutate;
+      return { mutate: vi.fn() };
+    });
+
+    render(<QueuePage pin="1234" />);
+
+    const ctx = capturedOnMutate?.({ trackId: "sweet-child", vote: 1, pin: "1234" });
+    act(() => {
+      capturedOnError?.({ data: { code: "INTERNAL_SERVER_ERROR" } }, { trackId: "sweet-child", vote: 1, pin: "1234" }, ctx);
+    });
+    expect(screen.getByTestId("vote-error-sweet-child")).toBeInTheDocument();
+
+    act(() => {
+      capturedOnSuccess?.({}, { trackId: "sweet-child", vote: 1, pin: "1234" }, ctx);
+    });
+    expect(screen.queryByTestId("vote-error-sweet-child")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -24,6 +24,13 @@ vi.mock("~/utils/api", () => ({
         }),
       },
     },
+    vote: {
+      byFissaFromUser: {
+        useQuery: vi.fn().mockReturnValue({
+          data: undefined,
+        }),
+      },
+    },
   },
 }));
 
@@ -1323,5 +1330,105 @@ describe("/fissa/$pin — App-open CTAs visually secondary (Task #89)", () => {
     const desktopCta = screen.getByTestId("open-desktop-app-cta");
 
     expect(mobileCta.className).toBe(desktopCta.className);
+  });
+});
+
+describe("/fissa/$pin — Fetch existing votes on load (Task #69)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockVoteByFissaFromUser = vi.mocked(api.vote.byFissaFromUser.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+
+  const activeFissaData = {
+    pin: "ABC123",
+    currentlyPlayingId: null,
+    tracks: [
+      { trackId: "track-123", hasBeenPlayed: false, durationMs: 180000, score: 0, totalScore: 3 },
+      { trackId: "track-456", hasBeenPlayed: false, durationMs: 180000, score: 0, totalScore: 1 },
+    ],
+  };
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: activeFissaData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+    mockVoteByFissaFromUser.mockReturnValue({ data: undefined } as any);
+  });
+
+  /**
+   * Scenario: Guest's previously cast upvote is shown on load
+   *   Given I am signed in as a Party Guest
+   *   And I previously upvoted track "track-123"
+   *   When I load the Fissa page
+   *   Then the upvote button for "track-123" shows as active/selected
+   */
+  it("calls vote.byFissaFromUser with { pin } when user is authenticated", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test" } },
+      isPending: false,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(mockVoteByFissaFromUser).toHaveBeenCalledWith(
+      { pin: "ABC123" },
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+
+  it("does not call vote.byFissaFromUser when user is unauthenticated", () => {
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(mockVoteByFissaFromUser).toHaveBeenCalledWith(
+      { pin: "ABC123" },
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it("shows upvote button as aria-pressed=true for a previously upvoted track", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test" } },
+      isPending: false,
+    } as any);
+    mockVoteByFissaFromUser.mockReturnValue({
+      data: [{ trackId: "track-123", score: 1 }],
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("upvote-track-123")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("downvote-track-123")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("shows downvote button as aria-pressed=true for a previously downvoted track", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test" } },
+      isPending: false,
+    } as any);
+    mockVoteByFissaFromUser.mockReturnValue({
+      data: [{ trackId: "track-456", score: -1 }],
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("upvote-track-456")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("downvote-track-456")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows both vote buttons as aria-pressed=false for unvoted tracks", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test" } },
+      isPending: false,
+    } as any);
+    mockVoteByFissaFromUser.mockReturnValue({ data: [] } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("upvote-track-123")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("downvote-track-123")).toHaveAttribute("aria-pressed", "false");
   });
 });

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -13,6 +13,10 @@ import React from "react";
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 // Note: vi.mock factories are hoisted — no variable references allowed inside.
 
+vi.mock("~/hooks/useTrackSearch", () => ({
+  useTrackSearch: () => ({ results: [], isLoading: false, query: "", setQuery: vi.fn() }),
+}));
+
 vi.mock("~/utils/api", () => ({
   api: {
     fissa: {

--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -7,7 +7,7 @@
  * Scenario: Authenticated user does not see Sign in CTA (Task #58)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -30,7 +30,20 @@ vi.mock("~/utils/api", () => ({
           data: undefined,
         }),
       },
+      create: {
+        useMutation: vi.fn().mockReturnValue({
+          mutate: vi.fn(),
+        }),
+      },
     },
+    useUtils: vi.fn().mockReturnValue({
+      vote: {
+        byFissaFromUser: { invalidate: vi.fn().mockResolvedValue(undefined) },
+      },
+      fissa: {
+        byId: { invalidate: vi.fn().mockResolvedValue(undefined) },
+      },
+    }),
   },
 }));
 
@@ -1430,5 +1443,197 @@ describe("/fissa/$pin — Fetch existing votes on load (Task #69)", () => {
 
     expect(screen.getByTestId("upvote-track-123")).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByTestId("downvote-track-123")).toHaveAttribute("aria-pressed", "false");
+  });
+});
+
+describe("/fissa/$pin — Wire vote.create mutation (Task #71)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockVoteByFissaFromUser = vi.mocked(api.vote.byFissaFromUser.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+  const mockCreateVoteMutation = vi.mocked(api.vote.create.useMutation);
+
+  const activeFissaData = {
+    pin: "ABC123",
+    currentlyPlayingId: null,
+    tracks: [
+      { trackId: "track-dancing-queen", hasBeenPlayed: false, durationMs: 180000, score: 0, totalScore: 0 },
+      { trackId: "track-barbie-girl", hasBeenPlayed: false, durationMs: 180000, score: 0, totalScore: 0 },
+    ],
+  };
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: activeFissaData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+    mockVoteByFissaFromUser.mockReturnValue({ data: [] } as any);
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "user1", name: "Test Guest" } },
+      isPending: false,
+    } as any);
+  });
+
+  /**
+   * Scenario: Guest casts an upvote
+   *   Given I am signed in as a Party Guest
+   *   And track "Dancing Queen" is in the Queue
+   *   When I click the upvote button on "Dancing Queen"
+   *   Then the upvote button is shown as active immediately (optimistic)
+   *   And the vote.create mutation is called with score +1
+   */
+  it("calls vote.create mutation with score +1 when upvote button is clicked", () => {
+    const mockMutate = vi.fn();
+    mockCreateVoteMutation.mockReturnValue({ mutate: mockMutate } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    fireEvent.click(screen.getByTestId("upvote-track-dancing-queen"));
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      pin: "ABC123",
+      trackId: "track-dancing-queen",
+      vote: 1,
+    });
+  });
+
+  /**
+   * Scenario: Guest casts a downvote
+   *   Given I am signed in as a Party Guest
+   *   And track "Barbie Girl" is in the Queue
+   *   When I click the downvote button on "Barbie Girl"
+   *   Then the vote.create mutation is called with score -1
+   */
+  it("calls vote.create mutation with score -1 when downvote button is clicked", () => {
+    const mockMutate = vi.fn();
+    mockCreateVoteMutation.mockReturnValue({ mutate: mockMutate } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    fireEvent.click(screen.getByTestId("downvote-track-barbie-girl"));
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      pin: "ABC123",
+      trackId: "track-barbie-girl",
+      vote: -1,
+    });
+  });
+
+  /**
+   * Scenario: Guest casts an upvote — optimistic update shown immediately
+   *   When I click the upvote button
+   *   Then the upvote button shows as active immediately (before server responds)
+   */
+  it("shows upvote button as aria-pressed=true immediately after clicking (optimistic update)", () => {
+    // Simulate onMutate being called immediately by calling it inline
+    mockCreateVoteMutation.mockImplementation(({ onMutate }: any) => ({
+      mutate: (input: any) => {
+        onMutate?.(input);
+      },
+    }));
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("upvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(screen.getByTestId("upvote-track-dancing-queen"));
+
+    expect(screen.getByTestId("upvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("downvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  /**
+   * Scenario: Guest casts a downvote — optimistic update shown immediately
+   */
+  it("shows downvote button as aria-pressed=true immediately after clicking (optimistic update)", () => {
+    mockCreateVoteMutation.mockImplementation(({ onMutate }: any) => ({
+      mutate: (input: any) => {
+        onMutate?.(input);
+      },
+    }));
+
+    render(<QueuePage pin="ABC123" />);
+
+    fireEvent.click(screen.getByTestId("downvote-track-barbie-girl"));
+
+    expect(screen.getByTestId("downvote-track-barbie-girl")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("upvote-track-barbie-girl")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  /**
+   * Scenario: Guest changes vote from upvote to downvote
+   *   Given I previously upvoted "Dancing Queen"
+   *   When I click the downvote button on "Dancing Queen"
+   *   Then the downvote button becomes active and upvote becomes inactive
+   *   And vote.create is called with score -1
+   */
+  it("changes active vote from upvote to downvote when clicking downvote (optimistic)", () => {
+    mockCreateVoteMutation.mockImplementation(({ onMutate }: any) => ({
+      mutate: (input: any) => {
+        onMutate?.(input);
+      },
+    }));
+    // Start with an existing upvote on the track
+    mockVoteByFissaFromUser.mockReturnValue({
+      data: [{ trackId: "track-dancing-queen", score: 1 }],
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    // Initially upvote is active
+    expect(screen.getByTestId("upvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("downvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "false");
+
+    // Click downvote to change the vote
+    fireEvent.click(screen.getByTestId("downvote-track-dancing-queen"));
+
+    // Downvote is now active, upvote is inactive
+    expect(screen.getByTestId("downvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("upvote-track-dancing-queen")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  /**
+   * Scenario: vote.create is not called for unauthenticated users
+   *   (vote buttons are not rendered for unauthenticated users — verified by prior tests)
+   */
+  it("does not expose onVote when user is not authenticated", () => {
+    const mockMutate = vi.fn();
+    mockCreateVoteMutation.mockReturnValue({ mutate: mockMutate } as any);
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    // No vote buttons should be in the DOM for unauthenticated users
+    expect(screen.queryByTestId("upvote-track-dancing-queen")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("downvote-track-dancing-queen")).not.toBeInTheDocument();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Scenario: On success, cache invalidation is triggered
+   */
+  it("invalidates vote.byFissaFromUser and fissa.byId on mutation success", () => {
+    const mockInvalidateVotes = vi.fn().mockResolvedValue(undefined);
+    const mockInvalidateFissa = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(api.useUtils).mockReturnValue({
+      vote: { byFissaFromUser: { invalidate: mockInvalidateVotes } },
+      fissa: { byId: { invalidate: mockInvalidateFissa } },
+    } as any);
+
+    let capturedOnSuccess: ((data: any) => void) | undefined;
+    mockCreateVoteMutation.mockImplementation(({ onSuccess }: any) => {
+      capturedOnSuccess = onSuccess;
+      return { mutate: vi.fn() };
+    });
+
+    render(<QueuePage pin="ABC123" />);
+
+    // Simulate success callback
+    capturedOnSuccess?.({});
+
+    expect(mockInvalidateVotes).toHaveBeenCalledWith({ pin: "ABC123" });
+    expect(mockInvalidateFissa).toHaveBeenCalledWith("ABC123");
   });
 });

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -23,6 +23,13 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
   const { data: session, isPending: sessionPending } = authClient.useSession();
   const navigate = useNavigate({ from: "/fissa/$pin" });
   const dismissError = () => void navigate({ to: "/fissa/$pin", params: { pin }, search: {} });
+  const { data: votesData } = api.vote.byFissaFromUser.useQuery(
+    { pin },
+    { enabled: !!pin && !!session?.user },
+  );
+  const userVotes = new Map(
+    (votesData ?? []).map((v) => [v.trackId, v.score as 1 | -1]),
+  );
   const { data, isLoading, isError } = api.fissa.byId.useQuery(pin, {
     retry: false,
     enabled: !!pin,
@@ -102,7 +109,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
               No upcoming tracks
             </p>
           ) : (
-            <QueueTrackList tracks={upcomingTracks} isAuthenticated={!!session?.user} currentlyPlayingId={data?.currentlyPlayingId ?? undefined} />
+            <QueueTrackList tracks={upcomingTracks} isAuthenticated={!!session?.user} currentlyPlayingId={data?.currentlyPlayingId ?? undefined} userVotes={session?.user ? userVotes : undefined} />
           )}
         </section>
 

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -102,7 +102,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
               No upcoming tracks
             </p>
           ) : (
-            <QueueTrackList tracks={upcomingTracks} />
+            <QueueTrackList tracks={upcomingTracks} isAuthenticated={!!session?.user} />
           )}
         </section>
 

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useCallback, useState } from "react";
 import { type FC } from "react";
 import { CurrentlyPlayingTrack } from "~/components/CurrentlyPlayingTrack";
 import { Layout } from "~/components/Layout";
@@ -23,13 +24,56 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
   const { data: session, isPending: sessionPending } = authClient.useSession();
   const navigate = useNavigate({ from: "/fissa/$pin" });
   const dismissError = () => void navigate({ to: "/fissa/$pin", params: { pin }, search: {} });
+
+  // Optimistic vote state: trackId -> score
+  const [optimisticVotes, setOptimisticVotes] = useState<Map<string, 1 | -1>>(new Map());
+
   const { data: votesData } = api.vote.byFissaFromUser.useQuery(
     { pin },
     { enabled: !!pin && !!session?.user },
   );
+
+  const utils = api.useUtils();
+
+  const { mutate: createVote } = api.vote.create.useMutation({
+    onMutate: ({ trackId, vote }) => {
+      // Optimistic update: immediately reflect new vote state
+      setOptimisticVotes((prev) => {
+        const next = new Map(prev);
+        next.set(trackId, vote as 1 | -1);
+        return next;
+      });
+    },
+    onSuccess: async () => {
+      // Invalidate queries to refresh data from server
+      await utils.vote.byFissaFromUser.invalidate({ pin });
+      await utils.fissa.byId.invalidate(pin);
+    },
+    onError: (_err, { trackId }) => {
+      // Rollback optimistic update on error (full error handling is Task #78)
+      setOptimisticVotes((prev) => {
+        const next = new Map(prev);
+        next.delete(trackId);
+        return next;
+      });
+    },
+  });
+
+  // Merge server votes with optimistic updates (optimistic takes precedence)
   const userVotes = new Map(
     (votesData ?? []).map((v) => [v.trackId, v.score as 1 | -1]),
   );
+  for (const [trackId, score] of optimisticVotes) {
+    userVotes.set(trackId, score);
+  }
+
+  const handleVote = useCallback(
+    (trackId: string, vote: 1 | -1) => {
+      createVote({ pin, trackId, vote });
+    },
+    [createVote, pin],
+  );
+
   const { data, isLoading, isError } = api.fissa.byId.useQuery(pin, {
     retry: false,
     enabled: !!pin,
@@ -109,7 +153,13 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
               No upcoming tracks
             </p>
           ) : (
-            <QueueTrackList tracks={upcomingTracks} isAuthenticated={!!session?.user} currentlyPlayingId={data?.currentlyPlayingId ?? undefined} userVotes={session?.user ? userVotes : undefined} />
+            <QueueTrackList
+              tracks={upcomingTracks}
+              isAuthenticated={!!session?.user}
+              currentlyPlayingId={data?.currentlyPlayingId ?? undefined}
+              userVotes={session?.user ? userVotes : undefined}
+              onVote={session?.user ? handleVote : undefined}
+            />
           )}
         </section>
 

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -21,43 +21,24 @@ interface QueuePageProps {
 }
 
 export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
+  const [optimisticVotes, setOptimisticVotes] = useState<Map<string, 1 | -1>>(new Map());
+  const [voteErrors, setVoteErrors] = useState<Map<string, { vote: 1 | -1 }>>(new Map());
   const { data: session, isPending: sessionPending } = authClient.useSession();
   const navigate = useNavigate({ from: "/fissa/$pin" });
   const dismissError = () => void navigate({ to: "/fissa/$pin", params: { pin }, search: {} });
+  const utils = api.useUtils();
 
-  // Optimistic vote state: trackId -> score
-  const [optimisticVotes, setOptimisticVotes] = useState<Map<string, 1 | -1>>(new Map());
+  const { data, isLoading, isError } = api.fissa.byId.useQuery(pin, {
+    retry: false,
+    enabled: !!pin,
+    refetchInterval: 5000,
+    refetchIntervalInBackground: false,
+  });
 
   const { data: votesData } = api.vote.byFissaFromUser.useQuery(
     { pin },
     { enabled: !!pin && !!session?.user },
   );
-
-  const utils = api.useUtils();
-
-  const { mutate: createVote } = api.vote.create.useMutation({
-    onMutate: ({ trackId, vote }) => {
-      // Optimistic update: immediately reflect new vote state
-      setOptimisticVotes((prev) => {
-        const next = new Map(prev);
-        next.set(trackId, vote as 1 | -1);
-        return next;
-      });
-    },
-    onSuccess: async () => {
-      // Invalidate queries to refresh data from server
-      await utils.vote.byFissaFromUser.invalidate({ pin });
-      await utils.fissa.byId.invalidate(pin);
-    },
-    onError: (_err, { trackId }) => {
-      // Rollback optimistic update on error (full error handling is Task #78)
-      setOptimisticVotes((prev) => {
-        const next = new Map(prev);
-        next.delete(trackId);
-        return next;
-      });
-    },
-  });
 
   // Merge server votes with optimistic updates (optimistic takes precedence)
   const userVotes = new Map(
@@ -67,6 +48,45 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
     userVotes.set(trackId, score);
   }
 
+  const { mutate: createVote } = api.vote.create.useMutation({
+    onMutate: ({ trackId, vote }) => {
+      const previousVote = optimisticVotes.get(trackId) ?? null;
+      setOptimisticVotes((prev) => {
+        const next = new Map(prev);
+        next.set(trackId, vote as 1 | -1);
+        return next;
+      });
+      return { previousVote, trackId };
+    },
+    onSuccess: (_data: unknown, vars?: { trackId?: string }) => {
+      if (vars?.trackId) {
+        setVoteErrors((prev) => {
+          const next = new Map(prev);
+          next.delete(vars.trackId!);
+          return next;
+        });
+      }
+      void utils.vote.byFissaFromUser.invalidate({ pin });
+      void utils.fissa.byId.invalidate(pin);
+    },
+    onError: (err, { trackId, vote }, context) => {
+      setOptimisticVotes((prev) => {
+        const next = new Map(prev);
+        if (context?.previousVote != null) {
+          next.set(trackId, context.previousVote as 1 | -1);
+        } else {
+          next.delete(trackId);
+        }
+        return next;
+      });
+      setVoteErrors((prev) => new Map(prev).set(trackId, { vote: vote as 1 | -1 }));
+      const tRPCError = err as { data?: { code?: string } };
+      if (tRPCError?.data?.code === "NOT_FOUND") {
+        void utils.fissa.byId.invalidate(pin);
+      }
+    },
+  });
+
   const handleVote = useCallback(
     (trackId: string, vote: 1 | -1) => {
       createVote({ pin, trackId, vote });
@@ -74,12 +94,17 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
     [createVote, pin],
   );
 
-  const { data, isLoading, isError } = api.fissa.byId.useQuery(pin, {
-    retry: false,
-    enabled: !!pin,
-    refetchInterval: 5000,
-    refetchIntervalInBackground: false,
-  });
+  const handleRetryVote = useCallback(
+    (trackId: string, vote: 1 | -1) => {
+      setVoteErrors((prev) => {
+        const next = new Map(prev);
+        next.delete(trackId);
+        return next;
+      });
+      createVote({ pin, trackId, vote });
+    },
+    [createVote, pin],
+  );
 
   if (isLoading) {
     return (
@@ -159,6 +184,8 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
               currentlyPlayingId={data?.currentlyPlayingId ?? undefined}
               userVotes={session?.user ? userVotes : undefined}
               onVote={session?.user ? handleVote : undefined}
+              voteErrors={voteErrors}
+              onRetryVote={handleRetryVote}
             />
           )}
         </section>
@@ -200,7 +227,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
             <button data-testid="add-track-btn" className="w-full rounded-full bg-primary px-6 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90" type="button">
               Add Track
             </button>
-            <div data-testid="vote-controls">{/* Vote controls — Feature #47 */}</div>
+            <div data-testid="vote-controls">{/* Vote controls wired via QueueTrackList */}</div>
           </section>
         )}
       </div>

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useCallback, useState } from "react";
 import { type FC } from "react";
+import { AddTrackSheet } from "~/components/AddTrackSheet";
 import { CurrentlyPlayingTrack } from "~/components/CurrentlyPlayingTrack";
 import { Layout } from "~/components/Layout";
 import { QueueTrackList } from "~/components/QueueTrackList";
@@ -21,6 +22,7 @@ interface QueuePageProps {
 }
 
 export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [optimisticVotes, setOptimisticVotes] = useState<Map<string, 1 | -1>>(new Map());
   const [voteErrors, setVoteErrors] = useState<Map<string, { vote: 1 | -1 }>>(new Map());
   const { data: session, isPending: sessionPending } = authClient.useSession();
@@ -224,13 +226,19 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
         {/* Queue interaction controls — visible only for authenticated guests */}
         {session?.user && (
           <section data-testid="queue-interaction-controls" className="px-4 py-4">
-            <button data-testid="add-track-btn" className="w-full rounded-full bg-primary px-6 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90" type="button">
+            <button
+              data-testid="add-track-btn"
+              className="w-full rounded-full bg-primary px-6 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+              type="button"
+              onClick={() => setIsSheetOpen(true)}
+            >
               Add Track
             </button>
             <div data-testid="vote-controls">{/* Vote controls wired via QueueTrackList */}</div>
           </section>
         )}
       </div>
+      <AddTrackSheet isOpen={isSheetOpen} onClose={() => setIsSheetOpen(false)} pin={pin} />
     </Layout>
   );
 };

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -102,7 +102,7 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
               No upcoming tracks
             </p>
           ) : (
-            <QueueTrackList tracks={upcomingTracks} isAuthenticated={!!session?.user} />
+            <QueueTrackList tracks={upcomingTracks} isAuthenticated={!!session?.user} currentlyPlayingId={data?.currentlyPlayingId ?? undefined} />
           )}
         </section>
 

--- a/packages/api/src/infrastructure/SpotifyService.ts
+++ b/packages/api/src/infrastructure/SpotifyService.ts
@@ -120,4 +120,19 @@ export class SpotifyService implements ISpotifyService {
       }
     }
   };
+
+  searchTracks = async (
+    accessToken: string,
+    query: string,
+  ): Promise<Array<{ id: string; name: string; artists: string[]; albumArt: string }>> => {
+    const { body } = await this.withRetry(() =>
+      this.createClient(accessToken).search(query, ["track"], { limit: 20 }),
+    );
+    return (body.tracks?.items ?? []).map((track) => ({
+      id: track.id,
+      name: track.name,
+      artists: track.artists.map((a) => a.name),
+      albumArt: track.album.images[0]?.url ?? "",
+    }));
+  };
 }

--- a/packages/api/src/interfaces/IUserRepository.ts
+++ b/packages/api/src/interfaces/IUserRepository.ts
@@ -48,6 +48,8 @@ export interface IUserRepository {
 
   findFissaOwnerRefreshData(pin: string): Promise<FissaOwnerRefreshData | undefined>;
 
+  getSpotifyAccessToken(userId: string): Promise<string | null>;
+
   createUserWithAccount(
     spotifyUser: SpotifyApi.CurrentUsersProfileResponse,
     tokens: Awaited<ReturnType<ISpotifyService["codeGrant"]>>,

--- a/packages/api/src/repository/UserRepository.ts
+++ b/packages/api/src/repository/UserRepository.ts
@@ -103,6 +103,14 @@ export class UserRepository implements IUserRepository {
     };
   };
 
+  getSpotifyAccessToken = async (userId: string): Promise<string | null> => {
+    const account = await this.db.query.accounts.findFirst({
+      where: and(eq(accounts.userId, userId), eq(accounts.providerId, "spotify")),
+      columns: { accessToken: true },
+    });
+    return account?.accessToken ?? null;
+  };
+
   createUserWithAccount = async (
     spotifyUser: SpotifyApi.CurrentUsersProfileResponse,
     tokens: Awaited<ReturnType<ISpotifyService["codeGrant"]>>,

--- a/packages/api/src/root.ts
+++ b/packages/api/src/root.ts
@@ -1,5 +1,6 @@
 import { authRouter } from "./router/auth";
 import { fissaRouter } from "./router/fissa";
+import { spotifyRouter } from "./router/spotify";
 import { trackRouter } from "./router/track";
 import { voteRouter } from "./router/vote";
 import { createTRPCRouter } from "./trpc";
@@ -7,6 +8,7 @@ import { createTRPCRouter } from "./trpc";
 export const appRouter = createTRPCRouter({
   auth: authRouter,
   fissa: fissaRouter,
+  spotify: spotifyRouter,
   track: trackRouter,
   vote: voteRouter,
 });

--- a/packages/api/src/router/spotify.ts
+++ b/packages/api/src/router/spotify.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { SpotifyService } from "../infrastructure/SpotifyService";
+import { UserRepository } from "../repository";
+
+export const spotifyRouter = createTRPCRouter({
+  searchTracks: protectedProcedure
+    .input(z.object({ query: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const userRepo = new UserRepository(ctx.database);
+      const accessToken = await userRepo.getSpotifyAccessToken(ctx.session.user.id);
+      if (!accessToken) throw new TRPCError({ code: "UNAUTHORIZED", message: "No Spotify access token" });
+      const spotifyService = new SpotifyService();
+      const tracks = await spotifyService.searchTracks(accessToken, input.query);
+      return { tracks };
+    }),
+});


### PR DESCRIPTION
## Summary

- Add `useTrackSearch` custom hook wrapping `useDebounce` + `api.spotify.searchTracks` with `{ results, isLoading, query, setQuery }` interface
- Add `AddTrackSheet` component with debounced search input, loading indicator, and results list (Tasks #72 + #74)
- Add `spotify.searchTracks` tRPC endpoint + `SpotifyService.searchTracks` + `UserRepository.getSpotifyAccessToken`
- Wire Add Track button in `QueuePage` to open `AddTrackSheet`; empty/whitespace queries never trigger search

Closes #72

## Test plan

- [x] `useTrackSearch.test.ts` — 7 tests covering empty query guard, debounced search enable, loading state, results population
- [x] `AddTrackSheet.test.tsx` — 13 tests covering all Gherkin scenarios (closed/open, loading, results, keyboard nav, artwork fallback)
- [x] `$pin.test.tsx` — 59 existing tests still pass with AddTrackSheet wired in

🤖 Generated with [Claude Code](https://claude.com/claude-code)
