### PR TITLE
feat(fissa): display pin with copy and share actions for host

### DIFF
--- a/apps/web/src/routes/fissa/$pin.test.tsx
+++ b/apps/web/src/routes/fissa/$pin.test.tsx
@@ -7,7 +7,7 @@
  * Scenario: Authenticated user does not see Sign in CTA (Task #58)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import React from "react";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -1323,5 +1323,152 @@ describe("/fissa/$pin — App-open CTAs visually secondary (Task #89)", () => {
     const desktopCta = screen.getByTestId("open-desktop-app-cta");
 
     expect(mobileCta.className).toBe(desktopCta.className);
+  });
+});
+
+describe("/fissa/$pin — Display PIN with copy/share for Host (Task #86)", () => {
+  const mockUseQuery = vi.mocked(api.fissa.byId.useQuery);
+  const mockUseSession = vi.mocked(authClient.useSession);
+
+  const activeFissaData = {
+    pin: "ABC123",
+    userId: "host-user-id",
+    currentlyPlayingId: null,
+    tracks: [],
+  };
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: activeFissaData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, "share", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("renders the host-pin-widget when the current user is the host", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "host-user-id", name: "Host" } },
+      isPending: false,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("host-pin-widget")).toBeInTheDocument();
+    expect(screen.getByTestId("host-pin-display")).toHaveTextContent("ABC123");
+  });
+
+  it("does not render the host-pin-widget when the current user is a guest", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "guest-user-id", name: "Guest" } },
+      isPending: false,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByTestId("host-pin-widget")).not.toBeInTheDocument();
+  });
+
+  it("does not render the host-pin-widget when the visitor is unauthenticated", () => {
+    mockUseSession.mockReturnValue({ data: null, isPending: false } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByTestId("host-pin-widget")).not.toBeInTheDocument();
+  });
+
+  it("does not render the host-pin-widget while session is pending", () => {
+    mockUseSession.mockReturnValue({ data: null, isPending: true } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByTestId("host-pin-widget")).not.toBeInTheDocument();
+  });
+
+  it("copies the PIN to clipboard when the Copy PIN button is clicked", async () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "host-user-id", name: "Host" } },
+      isPending: false,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("copy-pin-btn"));
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ABC123");
+  });
+
+  it("shows a confirmation message after the PIN is copied", async () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "host-user-id", name: "Host" } },
+      isPending: false,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("copy-pin-btn"));
+    });
+
+    expect(screen.getByTestId("copy-pin-confirmation")).toBeInTheDocument();
+  });
+
+  it("does not render the share button when Web Share API is unavailable", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "host-user-id", name: "Host" } },
+      isPending: false,
+    } as any);
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.queryByTestId("share-pin-btn")).not.toBeInTheDocument();
+  });
+
+  it("renders the share button when Web Share API is available", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "host-user-id", name: "Host" } },
+      isPending: false,
+    } as any);
+    Object.defineProperty(navigator, "share", {
+      value: vi.fn().mockResolvedValue(undefined),
+      writable: true,
+      configurable: true,
+    });
+
+    render(<QueuePage pin="ABC123" />);
+
+    expect(screen.getByTestId("share-pin-btn")).toBeInTheDocument();
+  });
+
+  it("shows a friendly error when clipboard API is blocked", async () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "host-user-id", name: "Host" } },
+      isPending: false,
+    } as any);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockRejectedValue(new Error("NotAllowedError")) },
+      writable: true,
+      configurable: true,
+    });
+
+    render(<QueuePage pin="ABC123" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("copy-pin-btn"));
+    });
+
+    expect(screen.getByTestId("copy-pin-error")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/fissa/$pin.tsx
+++ b/apps/web/src/routes/fissa/$pin.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { type FC } from "react";
+import { type FC, useCallback, useState } from "react";
 import { CurrentlyPlayingTrack } from "~/components/CurrentlyPlayingTrack";
 import { Layout } from "~/components/Layout";
 import { QueueTrackList } from "~/components/QueueTrackList";
@@ -13,6 +13,72 @@ export const Route = createFileRoute("/fissa/$pin")({
   }),
   component: JoinFissa,
 });
+
+
+interface HostPinWidgetProps {
+  pin: string;
+}
+
+const HostPinWidget: FC<HostPinWidgetProps> = ({ pin }) => {
+  const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
+  const hasShareApi = typeof navigator !== "undefined" && typeof navigator.share === "function";
+
+  const handleCopy = useCallback(async () => {
+    setCopyError(false);
+    try {
+      await navigator.clipboard.writeText(pin);
+      setCopied(true);
+    } catch {
+      setCopyError(true);
+    }
+  }, [pin]);
+
+  const handleShare = useCallback(async () => {
+    try {
+      await navigator.share({ title: "Join my Fissa!", text: `Use PIN: ${pin}`, url: window.location.href });
+    } catch {
+      // share was cancelled or failed — ignore
+    }
+  }, [pin]);
+
+  return (
+    <div data-testid="host-pin-widget" className="mx-4 mb-4 rounded-xl border border-primary/20 bg-primary/5 p-4 text-center">
+      <p className="mb-1 text-sm font-medium text-muted-foreground">Your Fissa PIN</p>
+      <p data-testid="host-pin-display" className="mb-3 text-4xl font-bold tracking-[0.3em]">{pin}</p>
+      <div className="flex justify-center gap-2">
+        <button
+          data-testid="copy-pin-btn"
+          type="button"
+          onClick={handleCopy}
+          className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+        >
+          Copy PIN
+        </button>
+        {hasShareApi && (
+          <button
+            data-testid="share-pin-btn"
+            type="button"
+            onClick={handleShare}
+            className="rounded-full border border-primary px-4 py-2 text-sm font-semibold text-primary transition-opacity hover:opacity-90"
+          >
+            Share
+          </button>
+        )}
+      </div>
+      {copied && (
+        <p data-testid="copy-pin-confirmation" className="mt-2 text-sm text-green-600">
+          PIN copied to clipboard!
+        </p>
+      )}
+      {copyError && (
+        <p data-testid="copy-pin-error" className="mt-2 text-sm text-destructive">
+          Could not copy — please copy the PIN manually: {pin}
+        </p>
+      )}
+    </div>
+  );
+};
 
 interface QueuePageProps {
   pin: string;
@@ -82,6 +148,8 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
     (t) => !t.hasBeenPlayed && t.trackId !== data?.currentlyPlayingId,
   ) ?? [];
 
+  const isHost = !sessionPending && !!session?.user && !!data?.userId && session.user.id === data.userId;
+
   return (
     <Layout>
       <div className="flex min-h-screen flex-col">
@@ -89,6 +157,9 @@ export const QueuePage: FC<QueuePageProps> = ({ pin, error }) => {
         <header className="px-4 py-6 text-center">
           <h1 className="text-2xl font-bold tracking-widest">{pin}</h1>
         </header>
+
+        {/* Host-only PIN widget */}
+        {isHost && <HostPinWidget pin={pin} />}
 
         {/* Currently-playing track slot */}
         <section data-testid="queue-now-playing" className="px-4 py-4">


### PR DESCRIPTION
## Summary

- Add `HostPinWidget` component to `/fissa/$pin` page — visible only when the logged-in user is the Fissa Host (`session.user.id === fissa.userId`)
- PIN displayed prominently with a Copy PIN button (clipboard API, confirmation on success, friendly error on block)
- Web Share API as progressive enhancement — share button appears only when `navigator.share` is available
- Guests and unauthenticated visitors never see the widget

## Test plan

- [x] Host sees `host-pin-widget` with correct PIN text
- [x] Guest (different user ID) does not see the widget
- [x] Unauthenticated visitor does not see the widget
- [x] Session-pending state does not show the widget
- [x] Copy PIN calls `navigator.clipboard.writeText` with correct PIN
- [x] Confirmation message shown after successful copy
- [x] Share button hidden when `navigator.share` is unavailable
- [x] Share button shown when `navigator.share` is available
- [x] Clipboard block shows friendly error (`copy-pin-error`)

Closes #86
Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)
